### PR TITLE
Removes an extra space

### DIFF
--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/SourceCodeViewController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/SourceCodeViewController.swift
@@ -71,7 +71,7 @@ class SourceCodeViewController: NSViewController, NSSearchFieldDelegate {
             "<link rel=\"stylesheet\" href=\"\(cssPath)\">" +
             "<script src=\"\(jsPath)\"></script>" +
             "<script>hljs.initHighlightingOnLoad();</script> </head> <body>" +
-            "<pre><code class=\"Swift\"> \(content) </code></pre>" +
+            "<pre><code class=\"Swift\">\(content)</code></pre>" +
         "</body> </html>"
         //        println(stringForHTML)
         // style=\"white-space:initial;\"


### PR DESCRIPTION
Removes a space that was inserted before the source code, causing the first line to always be offset.