### PR TITLE
Updates copyright info

### DIFF
--- a/arcgis-runtime-samples-macos/Info.plist
+++ b/arcgis-runtime-samples-macos/Info.plist
@@ -25,21 +25,8 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>//
-// Copyright 2016 Esri.
-//
-// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//</string>
+	<string>© 2016-2018 Esri.
+All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/arcgis-runtime-samples-macos/Info.plist
+++ b/arcgis-runtime-samples-macos/Info.plist
@@ -25,8 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2016-2018 Esri.
-All rights reserved.</string>
+	<string>© 2016 Esri.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
The copyright info has been updated to include the current year and the Apache License notice has been removed.

Before | After
------ | -----
![about before](https://user-images.githubusercontent.com/2257493/40863385-75502cc4-65a4-11e8-8b22-814312b4f5d3.png) | ![about after](https://user-images.githubusercontent.com/2257493/40863390-793e906e-65a4-11e8-98aa-c14777b4f15b.png)
![info before](https://user-images.githubusercontent.com/2257493/40863393-7db67184-65a4-11e8-8f14-82036ba93cd1.png) | ![info after](https://user-images.githubusercontent.com/2257493/40863394-81e14586-65a4-11e8-9281-86a7ebcf4498.png)
