### PR TITLE
Drops NSColor where possible

### DIFF
--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -39,7 +39,7 @@ class ViewshedGeoprocessingViewController: NSViewController, AGSGeoViewTouchDele
         self.mapView.touchDelegate = self
         
         //renderer for graphics overlays
-        let pointSymbol = AGSSimpleMarkerSymbol(style: .circle, color: NSColor.red, size: 10)
+        let pointSymbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 10)
         let renderer = AGSSimpleRenderer(symbol: pointSymbol)
         self.inputGraphicsOverlay.renderer = renderer
         

--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/CollectionViewController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/CollectionViewController.swift
@@ -93,10 +93,8 @@ class CollectionViewController: NSViewController, NSCollectionViewDataSource, NS
         }
         
         //stylize
-//        viewItem.view.backgroundColor = NSColor(white: 235/255.0, alpha: 1)
-        viewItem.view.backgroundColor = NSColor.white
+        viewItem.view.backgroundColor = .white
         viewItem.view.wantsLayer = true
-//        viewItem.view.layer?.borderColor = NSColor(white: 68/255.0, alpha: 1).CGColor
         viewItem.view.layer?.borderColor = NSColor.primaryBlue.cgColor
         viewItem.view.layer?.cornerRadius = 10
         viewItem.view.layer?.borderWidth = 1

--- a/arcgis-runtime-samples-macos/Content Display Logic/CustomSegmentedCell.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/CustomSegmentedCell.swift
@@ -104,9 +104,9 @@ class CustomSegmentedCell: NSSegmentedCell {
     private func textForSegment(_ segment:Int) -> NSAttributedString {
         let font = NSFont(name: "Avenir-Medium", size: 13)!
         
-        var textColor: NSColor
+        let textColor: NSColor
         if self.selectedSegment == segment {
-            textColor = NSColor.white
+            textColor = .white
         }
         else {
             textColor = self.tintColor

--- a/arcgis-runtime-samples-macos/Display information/Add graphics with renderer/GraphicsWithRendererViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Add graphics with renderer/GraphicsWithRendererViewController.swift
@@ -39,7 +39,7 @@ class GraphicsWithRendererViewController: NSViewController {
     func addGraphicsOverlay() {
         //point graphic
         let pointGeometry = AGSPoint(x: 40e5, y: 40e5, spatialReference: AGSSpatialReference.webMercator())
-        let pointSymbol = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.diamond, color: NSColor.red, size: 10)
+        let pointSymbol = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.diamond, color: .red, size: 10)
         let pointGraphic = AGSGraphic(geometry: pointGeometry, symbol: nil, attributes: nil)
         
         //create graphics overlay for point
@@ -60,7 +60,7 @@ class GraphicsWithRendererViewController: NSViewController {
         lineGeometry.addPointWith(x: -10e5, y: 40e5)
         lineGeometry.addPointWith(x: 20e5, y: 50e5)
     
-        let lineSymbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: NSColor.blue, width: 5)
+        let lineSymbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: .blue, width: 5)
         let lineGraphic = AGSGraphic(geometry: lineGeometry.toGeometry(), symbol: nil, attributes: nil)
         
         // create graphics overlay for polyline
@@ -82,7 +82,7 @@ class GraphicsWithRendererViewController: NSViewController {
         polygonGeometry.addPointWith(x: 20e5, y: 20e5)
         polygonGeometry.addPointWith(x: 20e5, y: -20e5)
         polygonGeometry.addPointWith(x: -20e5, y: -20e5)
-        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: NSColor.yellow, outline: nil)
+        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
         //create graphics overlay for polygon

--- a/arcgis-runtime-samples-macos/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -62,7 +62,7 @@ class GraphicsWithSymbolsViewController: NSViewController {
         let buoy4Loc = AGSPoint(x: -2.6395150461199726, y: 56.06127916736989, spatialReference: wgs84)
         
         //create a marker symbol
-        let buoyMarker = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.circle, color: NSColor.red, size: 10)
+        let buoyMarker = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.circle, color: .red, size: 10)
         
         //create graphics
         let buoyGraphic1 = AGSGraphic(geometry: buoy1Loc, symbol: buoyMarker, attributes: nil)

--- a/arcgis-runtime-samples-macos/Display information/Display grid/DisplayGridViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Display grid/DisplayGridViewController.swift
@@ -131,7 +131,7 @@ class DisplayGridViewController: NSViewController {
                 textSymbol.size = 14
                 textSymbol.horizontalAlignment = .left
                 textSymbol.verticalAlignment = .bottom
-                textSymbol.haloColor = NSColor.white
+                textSymbol.haloColor = .white
                 textSymbol.haloWidth = CGFloat(gridLevel+1)
                 mapView.grid?.setTextSymbol(textSymbol, forLevel: gridLevel)
             }

--- a/arcgis-runtime-samples-macos/Display information/Identify graphics/GOIdentifyViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Identify graphics/GOIdentifyViewController.swift
@@ -50,7 +50,7 @@ class GOIdentifyViewController: NSViewController, AGSGeoViewTouchDelegate {
         polygonGeometry.addPointWith(x: 20e5, y: 20e5)
         polygonGeometry.addPointWith(x: 20e5, y: -20e5)
         polygonGeometry.addPointWith(x: -20e5, y: -20e5)
-        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: NSColor.yellow, outline: nil)
+        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
         //initialize the graphics overlay

--- a/arcgis-runtime-samples-macos/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
@@ -43,7 +43,7 @@ class SimpleMarkerSymbolViewController: NSViewController {
     
     private func addSimpleMarkerSymbol() {
         //create a simple marker symbol
-        let symbol = AGSSimpleMarkerSymbol(style: .circle, color: NSColor.red, size: 12)
+        let symbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 12)
         
         //create point
         let point = AGSPoint(x: -226773, y: 6550477, spatialReference: AGSSpatialReference.webMercator())

--- a/arcgis-runtime-samples-macos/Display information/Simple renderer/SimpleRendererViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Simple renderer/SimpleRendererViewController.swift
@@ -66,7 +66,7 @@ class SimpleRendererViewController: NSViewController {
     
     private func addSimpleRenderer() {
         //create a simple renderer with red cross symbol
-        let simpleRenderer = AGSSimpleRenderer(symbol: AGSSimpleMarkerSymbol(style: .cross, color: NSColor.red, size: 15))
+        let simpleRenderer = AGSSimpleRenderer(symbol: AGSSimpleMarkerSymbol(style: .cross, color: .red, size: 15))
         
         //assign the renderer to the graphics overlay
         self.graphicsOverlay.renderer = simpleRenderer

--- a/arcgis-runtime-samples-macos/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -55,10 +55,10 @@ class UniqueValueRendererViewController: NSViewController {
         renderer.fieldNames = ["STATE_ABBR"]
         
         //create symbols to be used in the renderer
-        let defaultSymbol = AGSSimpleFillSymbol(style: .null, color: NSColor.clear, outline: AGSSimpleLineSymbol(style: .solid, color: NSColor.lightGray, width: 2))
-        let californiaSymbol = AGSSimpleFillSymbol(style: .solid, color: NSColor.red, outline: AGSSimpleLineSymbol(style: .solid, color: NSColor.red, width: 2))
-        let arizonaSymbol = AGSSimpleFillSymbol(style: .solid, color: NSColor.green, outline: AGSSimpleLineSymbol(style: .solid, color: NSColor.green, width: 2))
-        let nevadaSymbol = AGSSimpleFillSymbol(style: .solid, color: NSColor.blue, outline: AGSSimpleLineSymbol(style: .solid, color: NSColor.blue, width: 2))
+        let defaultSymbol = AGSSimpleFillSymbol(style: .null, color: .clear, outline: AGSSimpleLineSymbol(style: .solid, color: .lightGray, width: 2))
+        let californiaSymbol = AGSSimpleFillSymbol(style: .solid, color: .red, outline: AGSSimpleLineSymbol(style: .solid, color: .red, width: 2))
+        let arizonaSymbol = AGSSimpleFillSymbol(style: .solid, color: .green, outline: AGSSimpleLineSymbol(style: .solid, color: .green, width: 2))
+        let nevadaSymbol = AGSSimpleFillSymbol(style: .solid, color: .blue, outline: AGSSimpleLineSymbol(style: .solid, color: .blue, width: 2))
         
         //set the default symbol
         renderer.defaultSymbol = defaultSymbol

--- a/arcgis-runtime-samples-macos/Features/Add delete related features/AddDeleteRelatedFeaturesVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Add delete related features/AddDeleteRelatedFeaturesVC.swift
@@ -54,7 +54,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         
         //change selection width for feature layer
         self.parksFeatureLayer.selectionWidth = 4
-        self.parksFeatureLayer.selectionColor = NSColor.yellow
+        self.parksFeatureLayer.selectionColor = .yellow
         
         //add feature layer to the map
         map.operationalLayers.add(self.parksFeatureLayer)

--- a/arcgis-runtime-samples-macos/Features/Change feature layer renderer/ChangeFeatureLayerRendererVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Change feature layer renderer/ChangeFeatureLayerRendererVC.swift
@@ -51,7 +51,7 @@ class ChangeFeatureLayerRendererVC: NSViewController {
     
     @IBAction private func applyRenderer(_ sender:NSButton) {
         //create a symbol to be used in the renderer
-        let symbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: NSColor.blue, width: 2)
+        let symbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: .blue, width: 2)
         //create a new renderer using the symbol just created
         let renderer = AGSSimpleRenderer(symbol: symbol)
         //assign the new renderer to the feature layer

--- a/arcgis-runtime-samples-macos/Features/Feature collection layer/FeatureCollectionLayerVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature collection layer/FeatureCollectionLayerVC.swift
@@ -65,7 +65,7 @@ class FeatureCollectionLayerVC: NSViewController {
         let pointsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .point, spatialReference: AGSSpatialReference.wgs84())
         
         //renderer
-        let symbol = AGSSimpleMarkerSymbol(style: .triangle, color: NSColor.red, size: 18)
+        let symbol = AGSSimpleMarkerSymbol(style: .triangle, color: .red, size: 18)
         pointsCollectionTable.renderer = AGSSimpleRenderer(symbol: symbol)
         
         // Create a new point feature, provide geometry and attribute values
@@ -92,7 +92,7 @@ class FeatureCollectionLayerVC: NSViewController {
         let linesCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .polyline, spatialReference: AGSSpatialReference.wgs84())
         
         //renderer
-        let symbol = AGSSimpleLineSymbol(style: .dash, color: NSColor.green, width: 3)
+        let symbol = AGSSimpleLineSymbol(style: .dash, color: .green, width: 3)
         linesCollectionTable.renderer = AGSSimpleRenderer(symbol: symbol)
         
         // Create a new point feature, provide geometry and attribute values
@@ -122,8 +122,8 @@ class FeatureCollectionLayerVC: NSViewController {
         let polygonsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .polygon, spatialReference: AGSSpatialReference.wgs84())
         
         //renderer
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.blue, width: 2)
-        let fillSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: NSColor.cyan, outline: lineSymbol)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 2)
+        let fillSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: .cyan, outline: lineSymbol)
         polygonsCollectionTable.renderer = AGSSimpleRenderer(symbol: fillSymbol)
         
         // Create a new point feature, provide geometry and attribute values

--- a/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
@@ -44,7 +44,7 @@ class FeatureLayerQueryVC: NSViewController, NSTextFieldDelegate {
         self.featureLayer.selectionWidth = 4
         
         //set a new renderer
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.black, width: 1)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .black, width: 1)
         let fillSymbol = AGSSimpleFillSymbol(style: .solid, color: NSColor.yellow.withAlphaComponent(0.5), outline: lineSymbol)
         self.featureLayer.renderer = AGSSimpleRenderer(symbol: fillSymbol)
         

--- a/arcgis-runtime-samples-macos/Features/Feature layer selection/FeatureLayerSelectionVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature layer selection/FeatureLayerSelectionVC.swift
@@ -46,7 +46,7 @@ class FeatureLayerSelectionVC: NSViewController, AGSGeoViewTouchDelegate {
         
         //create feature layer using this feature table
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        self.featureLayer.selectionColor = NSColor.cyan
+        self.featureLayer.selectionColor = .cyan
         self.featureLayer.selectionWidth = 5
         
         //add feature layer to the map

--- a/arcgis-runtime-samples-macos/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-runtime-samples-macos/Features/List related features/ListRelatedFeaturesVC.swift
@@ -59,7 +59,7 @@ class ListRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, NSOutlin
         
         //change selection width for feature layer
         self.parksFeatureLayer.selectionWidth = 4
-        self.parksFeatureLayer.selectionColor = NSColor.yellow
+        self.parksFeatureLayer.selectionColor = .yellow
         
         //add parks feature layer to the map
         map.operationalLayers.add(self.parksFeatureLayer)

--- a/arcgis-runtime-samples-macos/Geometry/Create geometries/CreateGeometriesViewController.swift
+++ b/arcgis-runtime-samples-macos/Geometry/Create geometries/CreateGeometriesViewController.swift
@@ -34,9 +34,9 @@ class CreateGeometriesViewController: NSViewController {
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
         //create symbols for drawing graphics
-        let markerSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: NSColor.blue, size: 14)
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.blue, width: 3)
-        let fillSymbol = AGSSimpleFillSymbol(style: .cross, color: NSColor.blue, outline: nil)
+        let markerSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: .blue, size: 14)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 3)
+        let fillSymbol = AGSSimpleFillSymbol(style: .cross, color: .blue, outline: nil)
         
         //add a graphic of point, multipoint, polyline and polygon
         self.graphicsOverlay.graphics.add(AGSGraphic(geometry: self.createPoint(), symbol: markerSymbol, attributes: nil))

--- a/arcgis-runtime-samples-macos/Geometry/Format coordinates/FormatCoordinatesViewController.swift
+++ b/arcgis-runtime-samples-macos/Geometry/Format coordinates/FormatCoordinatesViewController.swift
@@ -69,7 +69,7 @@ class FormatCoordinatesViewController: NSViewController, AGSGeoViewTouchDelegate
         self.graphicsOverlay.graphics.removeAllObjects()
         
         //add graphic at tapped location
-        let symbol = AGSSimpleMarkerSymbol(style: .cross, color: NSColor.yellow, size: 20)
+        let symbol = AGSSimpleMarkerSymbol(style: .cross, color: .yellow, size: 20)
         let graphic = AGSGraphic(geometry: point, symbol: symbol, attributes: nil)
         self.graphicsOverlay.graphics.add(graphic)
     }

--- a/arcgis-runtime-samples-macos/Geometry/Spatial operations/SpatialOperationsViewController.swift
+++ b/arcgis-runtime-samples-macos/Geometry/Spatial operations/SpatialOperationsViewController.swift
@@ -26,7 +26,7 @@ class SpatialOperationsViewController: NSViewController {
     private var polygon1, polygon2: AGSPolygonBuilder!
     private var resultGraphic: AGSGraphic!
     
-    let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.black, width: 1)
+    let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .black, width: 1)
     
     let operations = ["None", "Union", "Difference", "Symmetric Difference", "Intersection"]
     
@@ -69,7 +69,7 @@ class SpatialOperationsViewController: NSViewController {
         polygon1.addPointWith(x: -13160, y: 6710100)
         
         //symbol
-        let fillSymbol1 = AGSSimpleFillSymbol(style: .solid, color: NSColor.blue, outline: lineSymbol)
+        let fillSymbol1 = AGSSimpleFillSymbol(style: .solid, color: .blue, outline: lineSymbol)
         
         //graphic
         let polygon1Graphic = AGSGraphic(geometry: polygon1.toGeometry(), symbol: fillSymbol1, attributes: nil)
@@ -96,7 +96,7 @@ class SpatialOperationsViewController: NSViewController {
         polygon2.parts.add(innerRing)
         
         //symbol
-        let fillSymbol2 = AGSSimpleFillSymbol(style: .solid, color: NSColor.green, outline: lineSymbol)
+        let fillSymbol2 = AGSSimpleFillSymbol(style: .solid, color: .green, outline: lineSymbol)
         
         //graphic
         let polygon2Graphic = AGSGraphic(geometry: polygon2.toGeometry(), symbol: fillSymbol2, attributes: nil)
@@ -124,7 +124,7 @@ class SpatialOperationsViewController: NSViewController {
         }
         
         //using red fill symbol for result with black border
-        let symbol = AGSSimpleFillSymbol(style: .solid, color: NSColor.red, outline: lineSymbol)
+        let symbol = AGSSimpleFillSymbol(style: .solid, color: .red, outline: lineSymbol)
         
         //create result graphic if not present
         if self.resultGraphic == nil {

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -97,7 +97,7 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
         markerSymbol.leaderOffsetY = markerSymbol.offsetY
         
         if isIndexRequired && index != nil {
-            let textSymbol = AGSTextSymbol(text: "\(index!)", color: NSColor.white, size: 20, horizontalAlignment: AGSHorizontalAlignment.center, verticalAlignment: AGSVerticalAlignment.middle)
+            let textSymbol = AGSTextSymbol(text: "\(index!)", color: .white, size: 20, horizontalAlignment: .center, verticalAlignment: .middle)
             textSymbol.offsetY = markerSymbol.offsetY
             
             let compositeSymbol = AGSCompositeSymbol(symbols: [markerSymbol, textSymbol])
@@ -108,7 +108,7 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
     }
     
     private func labelSymbolForStop(_ text:String) -> AGSTextSymbol {
-        let symbol = AGSTextSymbol(text: text, color: NSColor.white, size: 15, horizontalAlignment: .center, verticalAlignment: .middle)
+        let symbol = AGSTextSymbol(text: text, color: .white, size: 15, horizontalAlignment: .center, verticalAlignment: .middle)
         symbol.offsetY = 22
         return symbol
     }
@@ -121,7 +121,7 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
     
     //method returns the symbol for the route graphic
     func routeSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.blue, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 5)
         return symbol
     }
     

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewItem.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewItem.swift
@@ -51,11 +51,11 @@ class MobileMapViewItem: NSCollectionViewItem {
         didSet {
             if isSelected {
                 self.view.layer?.backgroundColor = NSColor.secondaryBlue.cgColor
-                self.label.textColor = NSColor.white
+                self.label.textColor = .white
             }
             else {
                 self.view.layer?.backgroundColor = NSColor.clear.cgColor
-                self.label.textColor = NSColor.black
+                self.label.textColor = .black
             }
         }
     }

--- a/arcgis-runtime-samples-macos/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
@@ -72,7 +72,7 @@ class FindServiceAreaInteractiveVC: NSViewController, AGSGeoViewTouchDelegate {
         self.facilitiesGraphicsOverlay.renderer = AGSSimpleRenderer(symbol: facilitySymbol)
         
         //barrier symbol
-        let barrierSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: NSColor.red, outline: nil)
+        let barrierSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: .red, outline: nil)
         
         //set symbol on barrier graphics overlay using renderer
         self.barriersGraphicsOverlay.renderer = AGSSimpleRenderer(symbol: barrierSymbol)

--- a/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/RouteAroundBarriersVC.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/RouteAroundBarriersVC.swift
@@ -150,12 +150,12 @@ class RouteAroundBarriersVC: NSViewController, AGSGeoViewTouchDelegate, Directio
     }
     
     func routeSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.yellow, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .solid, color: .yellow, width: 5)
         return symbol
     }
     
     func directionSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .dashDot, color: NSColor.orange, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .dashDot, color: .orange, width: 5)
         return symbol
     }
     
@@ -164,7 +164,7 @@ class RouteAroundBarriersVC: NSViewController, AGSGeoViewTouchDelegate, Directio
         let markerSymbol = AGSPictureMarkerSymbol(image: markerImage)
         markerSymbol.offsetY = markerImage.size.height/2
         
-        let textSymbol = AGSTextSymbol(text: "\(index)", color: NSColor.white, size: 20, horizontalAlignment: AGSHorizontalAlignment.center, verticalAlignment: AGSVerticalAlignment.middle)
+        let textSymbol = AGSTextSymbol(text: "\(index)", color: .white, size: 20, horizontalAlignment: .center, verticalAlignment: .middle)
         textSymbol.offsetY = markerSymbol.offsetY
         
         let compositeSymbol = AGSCompositeSymbol(symbols: [markerSymbol, textSymbol])
@@ -173,7 +173,7 @@ class RouteAroundBarriersVC: NSViewController, AGSGeoViewTouchDelegate, Directio
     }
     
     func barrierSymbol() -> AGSSimpleFillSymbol {
-        return AGSSimpleFillSymbol(style: .diagonalCross, color: NSColor.red, outline: nil)
+        return AGSSimpleFillSymbol(style: .diagonalCross, color: .red, outline: nil)
     }
     
     //MARK: - AGSGeoViewTouchDelegate

--- a/arcgis-runtime-samples-macos/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -47,7 +47,7 @@ class ExtrudeGraphicsViewController: NSViewController {
         
         //simple renderer with extrusion property
         let renderer = AGSSimpleRenderer()
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: NSColor.white, width: 1)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .white, width: 1)
         renderer.symbol = AGSSimpleFillSymbol(style: .solid, color: .primaryBlue, outline: lineSymbol)
         renderer.sceneProperties?.extrusionMode = .baseHeight
         renderer.sceneProperties?.extrusionExpression = "[height]"

--- a/arcgis-runtime-samples-macos/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
@@ -39,8 +39,8 @@ class FeatureLayerExtrusionViewController: NSViewController {
         // feature layer must be rendered dynamically for extrusion to work
         layer.renderingMode = .dynamic
         // setup the symbols used to display the features (US states) from the table
-        let lineSymbol = AGSSimpleLineSymbol(style:.solid, color:NSColor.blue, width:1.0)
-        let fillSymbol = AGSSimpleFillSymbol(style:.solid, color:NSColor.blue, outline:lineSymbol)
+        let lineSymbol = AGSSimpleLineSymbol(style:.solid, color: .blue, width: 1.0)
+        let fillSymbol = AGSSimpleFillSymbol(style:.solid, color: .blue, outline: lineSymbol)
         renderer = AGSSimpleRenderer(symbol: fillSymbol)
         // need to set an extrusion type, BASE HEIGHT extrudes each point from the feature individually
         renderer?.sceneProperties?.extrusionMode = .baseHeight

--- a/arcgis-runtime-samples-macos/Scenes/Scene properties expressions/ScenePropertiesExpressions.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Scene properties expressions/ScenePropertiesExpressions.swift
@@ -51,7 +51,7 @@ class ScenePropertiesExpressions: NSViewController {
         graphicsOverlay.renderer = renderer
         
         //create a red cone graphic
-        let coneSymbol = AGSSimpleMarkerSceneSymbol(style: .cone, color: NSColor.red, height: 200, width: 100, depth: 100, anchorPosition: .center)
+        let coneSymbol = AGSSimpleMarkerSceneSymbol(style: .cone, color: .red, height: 200, width: 100, depth: 100, anchorPosition: .center)
         coneSymbol.pitch = -90  //correct symbol's default pitch
         let conePoint = AGSPoint(x: 83.9, y: 28.404, z: 6000, spatialReference: AGSSpatialReference.wgs84())
         let coneAttributes = ["HEADING": 0, "PITCH": 0]

--- a/arcgis-runtime-samples-macos/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -65,10 +65,10 @@ class SurfacePlacementsViewController: NSViewController {
     }
 
     private func pointSymbol() -> AGSSimpleMarkerSceneSymbol {
-        return AGSSimpleMarkerSceneSymbol(style: .sphere, color: NSColor.red, height: 50, width: 50, depth: 50, anchorPosition: .center)
+        return AGSSimpleMarkerSceneSymbol(style: .sphere, color: .red, height: 50, width: 50, depth: 50, anchorPosition: .center)
     }
     
     private func textSymbol(_ text: String) -> AGSTextSymbol {
-        return AGSTextSymbol(text: text, color: NSColor.blue, size: 20, horizontalAlignment: .left, verticalAlignment: .middle)
+        return AGSTextSymbol(text: text, color: .blue, size: 20, horizontalAlignment: .left, verticalAlignment: .middle)
     }
 }


### PR DESCRIPTION
Takes advantage of type inference by removing explicit references to `NSColor` where possible.