### PR TITLE
Uses previously defined static URLs in all samples

### DIFF
--- a/arcgis-runtime-samples-macos/Analysis/Line of sight (location)/LineOfSightLocationViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Line of sight (location)/LineOfSightLocationViewController.swift
@@ -42,8 +42,6 @@ class LineOfSightLocationViewController: NSViewController, AGSGeoViewTouchDelega
         }
     }
 
-    private let ELEVATION_SERVICE_URL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -57,7 +55,7 @@ class LineOfSightLocationViewController: NSViewController, AGSGeoViewTouchDelega
         sceneView.scene = scene
 
         // initialize the elevation source with the service URL and add it to the base surface of the scene
-        let elevationSrc = AGSArcGISTiledElevationSource(url: ELEVATION_SERVICE_URL)
+        let elevationSrc = AGSArcGISTiledElevationSource(url: .worldElevationService)
         scene.baseSurface?.elevationSources.append(elevationSrc)
 
         // set the viewpoint specified by the camera position

--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (GeoElement)/ViewshedGeoElementViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (GeoElement)/ViewshedGeoElementViewController.swift
@@ -33,12 +33,12 @@ class ViewshedGeoElementViewController: NSViewController, AGSGeoViewTouchDelegat
         
         // add base surface for elevation data
         let surface = AGSSurface()
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "http://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .brestElevationService)
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
         
         // add a scene layer
-        let buildings = AGSArcGISSceneLayer(url: URL(string:"http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!)
+        let buildings = AGSArcGISSceneLayer(url: .brestBuildingsService)
         scene.operationalLayers.add(buildings)
         
         // create a graphics overlay for the tank

--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
@@ -21,9 +21,6 @@ class ViewshedCameraViewController: NSViewController {
     
     private var viewshed: AGSLocationViewshed!
     
-    private let ELEVATION_SERVICE_URL = URL(string: "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer")!
-    private let SCENE_LAYER_URL = URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -38,13 +35,13 @@ class ViewshedCameraViewController: NSViewController {
         self.sceneView.setViewpointCamera(camera)
         
         //initialize the elevation source with the elevation service URL
-        let elevationSrc = AGSArcGISTiledElevationSource(url: ELEVATION_SERVICE_URL)
+        let elevationSrc = AGSArcGISTiledElevationSource(url: .brestElevationService)
         
         //add the elevation source to the base surface of the scene
         scene.baseSurface?.elevationSources.append(elevationSrc)
         
         //initialize the scene layer with the scene layer URL and add it to the scene
-        let buldings = AGSArcGISSceneLayer(url: SCENE_LAYER_URL)
+        let buldings = AGSArcGISSceneLayer(url: .brestBuildingsService)
         scene.operationalLayers.add(buldings)
         
         //create a viewshed from the camera with minimum and maximum distance (in meters) from the observer (camera) at which visibility will be evaluated

--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
@@ -56,9 +56,6 @@ class ViewshedLocationViewController: NSViewController, AGSGeoViewTouchDelegate 
             }
         }
     }
-    
-    private let ELEVATION_SERVICE_URL = URL(string: "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer")!
-    private let SCENE_LAYER_URL = URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -78,11 +75,11 @@ class ViewshedLocationViewController: NSViewController, AGSGeoViewTouchDelegate 
         sceneView.setViewpointCamera(camera)
         
         // initialize the elevation source with the service URL and add it to the base surface of the scene
-        let elevationSrc = AGSArcGISTiledElevationSource(url: ELEVATION_SERVICE_URL)
+        let elevationSrc = AGSArcGISTiledElevationSource(url: .brestElevationService)
         scene.baseSurface?.elevationSources.append(elevationSrc)
         
         // initialize the scene layer with the scene layer URL and add it to the scene
-        let buildings = AGSArcGISSceneLayer(url: SCENE_LAYER_URL)
+        let buildings = AGSArcGISSceneLayer(url: .brestBuildingsService)
         scene.operationalLayers.add(buildings)
         
         // initialize a viewshed analysis object with arbitrary location (the location will be defined by the user), heading, pitch, view angles, and distance range (in meters) from which visibility is calculated from the observer location

--- a/arcgis-runtime-samples-macos/Info.plist
+++ b/arcgis-runtime-samples-macos/Info.plist
@@ -43,15 +43,6 @@
 				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
 				<false/>
 			</dict>
-			<key>arcgis.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
 			<key>arcgisonline.com</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
@@ -70,20 +61,20 @@
 				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
 				<false/>
 			</dict>
-            <key>tile.stamen.com</key>
-            <dict>
-                <key>NSIncludesSubdomains</key>
-                <true/>
-                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-                <true/>
-            </dict>
-            <key>certmapper.cr.usgs.gov</key>
-            <dict>
-                <key>NSIncludesSubdomains</key>
-                <false/>
-                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-                <true/>
-            </dict>
+			<key>tile.stamen.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>certmapper.cr.usgs.gov</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<false/>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 		</dict>
 	</dict>
 </dict>

--- a/arcgis-runtime-samples-macos/Info.plist
+++ b/arcgis-runtime-samples-macos/Info.plist
@@ -28,6 +28,13 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>arcgis.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>arcgisonline.com</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>

--- a/arcgis-runtime-samples-macos/Scenes/Animate 3D symbols/Animate3DSymbolsVC.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Animate 3D symbols/Animate3DSymbolsVC.swift
@@ -58,7 +58,7 @@ class Animate3DSymbolsVC: NSViewController {
         self.sceneView.scene = scene
         
         //elevation source
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .worldElevationService)
         
         //surface
         let surface = AGSSurface()

--- a/arcgis-runtime-samples-macos/Scenes/Display a scene/DisplaySceneViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Display a scene/DisplaySceneViewController.swift
@@ -35,7 +35,7 @@ class DisplaySceneViewController: NSViewController {
         
         // add base surface for elevation data
         let surface = AGSSurface()
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .worldElevationService)
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
     }

--- a/arcgis-runtime-samples-macos/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -55,7 +55,7 @@ class ExtrudeGraphicsViewController: NSViewController {
         
         // add base surface for elevation data
         let surface = AGSSurface()
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .worldElevationService)
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
       

--- a/arcgis-runtime-samples-macos/Scenes/Scene layer (URL)/SceneLayerURLViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Scene layer (URL)/SceneLayerURLViewController.swift
@@ -37,12 +37,12 @@ class SceneLayerURLViewController: NSViewController {
         
         // add base surface for elevation data
         let surface = AGSSurface()
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .worldElevationService)
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
         
         //scene layer
-        let sceneLayer = AGSArcGISSceneLayer(url: URL(string: "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!)
+        let sceneLayer = AGSArcGISSceneLayer(url: .brestBuildingsService)
         self.sceneView.scene?.operationalLayers.add(sceneLayer)
     }
     

--- a/arcgis-runtime-samples-macos/Scenes/Scene symbols/SceneSymbolsViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Scene symbols/SceneSymbolsViewController.swift
@@ -35,7 +35,7 @@ class SceneSymbolsViewController: NSViewController {
         
         // add base surface for elevation data
         let surface = AGSSurface()
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .worldElevationService)
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
         

--- a/arcgis-runtime-samples-macos/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -37,7 +37,7 @@ class SurfacePlacementsViewController: NSViewController {
         
         // add base surface for elevation data
         let surface = AGSSurface()
-        let elevationSource = AGSArcGISTiledElevationSource(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevationSource = AGSArcGISTiledElevationSource(url: .worldElevationService)
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
         

--- a/arcgis-runtime-samples-macos/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
+++ b/arcgis-runtime-samples-macos/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
@@ -32,7 +32,7 @@ class TerrainExaggerationViewController: NSViewController {
         super.viewDidLoad()
         
         // setup the surface with an elevation source and add the surface to the scene
-        let elevation = AGSArcGISTiledElevationSource(url: URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!)
+        let elevation = AGSArcGISTiledElevationSource(url: .worldElevationService)
         surface.elevationSources.append(elevation)
         scene.baseSurface = surface
         


### PR DESCRIPTION
This also removes the App Transport Security exception for arcgis.com as all arcgis.com URLs now use https.