### PR TITLE
Prevents "Source File:" label from being truncated

### DIFF
--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -1094,7 +1094,7 @@
                                             <action selector="popUpButtonAction:" target="lPX-Bg-gfI" id="y72-fg-gOg"/>
                                         </connections>
                                     </popUpButton>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rxD-Xh-xkB">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="rxD-Xh-xkB">
                                         <rect key="frame" x="18" y="11" width="75" height="17"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Source File:" id="raF-q1-HLV">
                                             <font key="font" metaFont="system"/>

--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -5,6 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
         <plugIn identifier="com.apple.WebKitIBPlugin" version="14113"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -1074,17 +1075,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="559" height="435"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <webView translatesAutoresizingMaskIntoConstraints="NO" id="yjd-69-o1y">
-                                <rect key="frame" x="0.0" y="36" width="559" height="349"/>
-                                <webPreferences key="preferences" defaultFontSize="16" defaultFixedFontSize="13" minimumFontSize="0">
-                                    <nil key="identifier"/>
-                                </webPreferences>
-                            </webView>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="OR7-Wf-OcB">
-                                <rect key="frame" x="90" y="390" width="380" height="40"/>
-                                <subviews>
+                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bO6-9M-l79" userLabel="Source Picker View">
+                                <rect key="frame" x="190" y="390" width="180" height="40"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="rxD-Xh-xkB">
+                                                <rect key="frame" x="-2" y="12" width="75" height="17"/>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Source File:" id="raF-q1-HLV">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GxK-pS-yNo">
-                                        <rect key="frame" x="97" y="6" width="266" height="26"/>
+                                        <rect key="frame" x="77" y="7" width="106" height="26"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="zbD-en-mGK">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="menu"/>
@@ -1094,26 +1097,27 @@
                                             <action selector="popUpButtonAction:" target="lPX-Bg-gfI" id="y72-fg-gOg"/>
                                         </connections>
                                     </popUpButton>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="rxD-Xh-xkB">
-                                        <rect key="frame" x="18" y="11" width="75" height="17"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Source File:" id="raF-q1-HLV">
-                                            <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
-                                </subviews>
+                                        </subviews>
                                 <constraints>
-                                    <constraint firstItem="GxK-pS-yNo" firstAttribute="leading" secondItem="rxD-Xh-xkB" secondAttribute="trailing" constant="8" id="5W9-yc-Yfp"/>
-                                    <constraint firstAttribute="trailing" secondItem="GxK-pS-yNo" secondAttribute="trailing" constant="20" id="Cha-XI-E1w"/>
-                                    <constraint firstItem="rxD-Xh-xkB" firstAttribute="centerY" secondItem="OR7-Wf-OcB" secondAttribute="centerY" id="IFp-70-Nrc"/>
-                                    <constraint firstAttribute="width" constant="380" id="M9X-Nd-pBs"/>
-                                    <constraint firstItem="rxD-Xh-xkB" firstAttribute="leading" secondItem="OR7-Wf-OcB" secondAttribute="leading" constant="20" id="Wx0-CM-k0J"/>
-                                    <constraint firstItem="GxK-pS-yNo" firstAttribute="centerY" secondItem="OR7-Wf-OcB" secondAttribute="centerY" id="mjQ-bj-ULU"/>
-                                    <constraint firstAttribute="height" constant="40" id="oj0-yP-vLn"/>
+                                    <constraint firstAttribute="height" constant="40" id="SKC-wg-YGn"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="180" id="sK7-Qe-ztt"/>
                                 </constraints>
-                            </customView>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="1Xi-AI-47q">
+                                        <visibilityPriorities>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                        </visibilityPriorities>
+                                        <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                        </customSpacing>
+                                    </stackView>
+                            <webView translatesAutoresizingMaskIntoConstraints="NO" id="yjd-69-o1y">
+                                <rect key="frame" x="0.0" y="36" width="559" height="349"/>
+                                <webPreferences key="preferences" defaultFontSize="16" defaultFixedFontSize="13" minimumFontSize="0">
+                                    <nil key="identifier"/>
+                                </webPreferences>
+                            </webView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="1Xi-AI-47q" userLabel="Search View">
                                 <rect key="frame" x="0.0" y="0.0" width="559" height="36"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a8z-bi-wcm">
@@ -1164,13 +1168,13 @@
                         <constraints>
                             <constraint firstItem="yjd-69-o1y" firstAttribute="leading" secondItem="k7Y-O1-xhC" secondAttribute="leading" id="FOO-LV-5Wm"/>
                             <constraint firstAttribute="trailing" secondItem="yjd-69-o1y" secondAttribute="trailing" id="HdQ-Fz-vF8"/>
+                            <constraint firstItem="bO6-9M-l79" firstAttribute="top" secondItem="k7Y-O1-xhC" secondAttribute="top" constant="5" id="Uaz-Yr-ulH"/>
                             <constraint firstAttribute="bottom" secondItem="1Xi-AI-47q" secondAttribute="bottom" id="VXB-4a-MAc"/>
                             <constraint firstItem="1Xi-AI-47q" firstAttribute="leading" secondItem="k7Y-O1-xhC" secondAttribute="leading" id="aeg-Ta-n2n"/>
-                            <constraint firstItem="yjd-69-o1y" firstAttribute="top" secondItem="OR7-Wf-OcB" secondAttribute="bottom" constant="5" id="bGi-Ux-fSp"/>
-                            <constraint firstItem="OR7-Wf-OcB" firstAttribute="centerX" secondItem="k7Y-O1-xhC" secondAttribute="centerX" id="fr5-qa-6T2"/>
+                            <constraint firstItem="bO6-9M-l79" firstAttribute="centerX" secondItem="k7Y-O1-xhC" secondAttribute="centerX" id="ef4-Rv-6bV"/>
                             <constraint firstItem="1Xi-AI-47q" firstAttribute="top" secondItem="yjd-69-o1y" secondAttribute="bottom" id="gJj-K9-AMj"/>
+                            <constraint firstItem="yjd-69-o1y" firstAttribute="top" secondItem="bO6-9M-l79" secondAttribute="bottom" constant="5" id="jTK-w1-YUk"/>
                             <constraint firstAttribute="trailing" secondItem="1Xi-AI-47q" secondAttribute="trailing" id="kvM-ye-PSI"/>
-                            <constraint firstItem="OR7-Wf-OcB" firstAttribute="top" secondItem="k7Y-O1-xhC" secondAttribute="top" constant="5" id="lcR-uq-L8Z"/>
                         </constraints>
                     </view>
                     <connections>


### PR DESCRIPTION
This would happen when source files names were on the longer side.

Before:
![screen shot 2018-06-14 at 1 31 36 pm](https://user-images.githubusercontent.com/2257493/41436783-94c5ecc8-6fd7-11e8-8280-d7a1ed367062.png)

After:
![screen shot 2018-06-14 at 1 32 19 pm](https://user-images.githubusercontent.com/2257493/41436795-9a519aca-6fd7-11e8-89f5-320014551b54.png)

