### PR TITLE
Uses default value of beginSheetModal completionHandler

### DIFF
--- a/arcgis-runtime-samples-macos/Analysis/Analyze hotspots/HotspotsViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Analyze hotspots/HotspotsViewController.swift
@@ -142,6 +142,6 @@ class HotspotsViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -402,7 +402,7 @@ class StatisticalQueryGroupAndSortViewController: NSViewController, NSTableViewD
             let alert = NSAlert()
             alert.messageText = messageText
             alert.informativeText = informativeText
-            alert.beginSheetModal(for: window, completionHandler: nil)
+            alert.beginSheetModal(for: window)
         }
     }
     

--- a/arcgis-runtime-samples-macos/Analysis/Statistical query/StatisticalQueryViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Statistical query/StatisticalQueryViewController.swift
@@ -108,7 +108,7 @@ class StatisticalQueryViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }
 

--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -163,6 +163,6 @@ class ViewshedGeoprocessingViewController: NSViewController, AGSGeoViewTouchDele
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -109,6 +109,6 @@ class AddFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -143,7 +143,7 @@ class DeleteFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate, A
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
     
     private func showConfirmationAlert() {
@@ -151,10 +151,10 @@ class DeleteFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate, A
         alert.informativeText = "Are you sure you want to delete?"
         alert.addButton(withTitle: "No")
         alert.addButton(withTitle: "Yes")
-        alert.beginSheetModal(for: self.view.window!, completionHandler: { [weak self] (response: NSApplication.ModalResponse) in
+        alert.beginSheetModal(for: self.view.window!) { [weak self] (response: NSApplication.ModalResponse) in
             if response == NSApplication.ModalResponse.alertSecondButtonReturn {
                 self?.deleteFeature(self!.selectedFeature)
             }
-        }) 
+        }
     }
 }

--- a/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
@@ -290,6 +290,6 @@ class EditFeaturesConnectedVC: NSViewController, AGSGeoViewTouchDelegate, AGSPop
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Features/Add delete related features/AddDeleteRelatedFeaturesVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Add delete related features/AddDeleteRelatedFeaturesVC.swift
@@ -333,6 +333,6 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
@@ -111,6 +111,6 @@ class FeatureLayerQueryVC: NSViewController, NSTextFieldDelegate {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Features/Feature layer selection/FeatureLayerSelectionVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature layer selection/FeatureLayerSelectionVC.swift
@@ -94,6 +94,6 @@ class FeatureLayerSelectionVC: NSViewController, AGSGeoViewTouchDelegate {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Features/Generate geodatabase/GenerateGeodatabaseVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Generate geodatabase/GenerateGeodatabaseVC.swift
@@ -196,6 +196,6 @@ class GenerateGeodatabaseVC: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-runtime-samples-macos/Features/List related features/ListRelatedFeaturesVC.swift
@@ -255,6 +255,6 @@ class ListRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, NSOutlin
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Features/Time based query/TimeBasedQueryVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Time based query/TimeBasedQueryVC.swift
@@ -88,7 +88,7 @@ class TimeBasedQueryVC: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
     
 }

--- a/arcgis-runtime-samples-macos/Layers/Raster function (service)/RasterFunctionServiceViewController.swift
+++ b/arcgis-runtime-samples-macos/Layers/Raster function (service)/RasterFunctionServiceViewController.swift
@@ -118,6 +118,6 @@ class RasterFunctionServiceViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Layers/Raster layer (file)/RasterLayerViewController.swift
+++ b/arcgis-runtime-samples-macos/Layers/Raster layer (file)/RasterLayerViewController.swift
@@ -63,6 +63,6 @@ class RasterLayerViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Layers/Raster layer (service)/RasterLayerUsingServiceVC.swift
+++ b/arcgis-runtime-samples-macos/Layers/Raster layer (service)/RasterLayerUsingServiceVC.swift
@@ -64,7 +64,7 @@ class RasterLayerUsingServiceVC : NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
     
 }

--- a/arcgis-runtime-samples-macos/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
+++ b/arcgis-runtime-samples-macos/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
@@ -58,7 +58,7 @@ class WMSLayerUsingURLViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
     
 }

--- a/arcgis-runtime-samples-macos/Layers/WMTS layer/WMTSLayerViewController.swift
+++ b/arcgis-runtime-samples-macos/Layers/WMTS layer/WMTSLayerViewController.swift
@@ -65,7 +65,7 @@ class WMTSLayerViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
     
 }

--- a/arcgis-runtime-samples-macos/Maps/Create and save a map/CreateOptionsViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Create and save a map/CreateOptionsViewController.swift
@@ -88,6 +88,6 @@ class CreateOptionsViewController: NSViewController {
         alert.messageText = "Info"
         alert.informativeText = text
         alert.addButton(withTitle: "OK")
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Maps/Create and save a map/CreateSaveMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Create and save a map/CreateSaveMapViewController.swift
@@ -147,7 +147,7 @@ class CreateSaveMapViewController: NSViewController, CreateOptionsVCDelegate, Sa
         self.portal.load { (error) -> Void in
             if let error = error {
                 if (error as NSError).code != NSUserCancelledError {
-                    NSAlert(error: error).beginSheetModal(for: self.view.window!, completionHandler: nil)
+                    NSAlert(error: error).beginSheetModal(for: self.view.window!)
                 }
             }
             else {
@@ -163,7 +163,7 @@ class CreateSaveMapViewController: NSViewController, CreateOptionsVCDelegate, Sa
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }
 

--- a/arcgis-runtime-samples-macos/Maps/Create and save a map/SaveMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Create and save a map/SaveMapViewController.swift
@@ -60,7 +60,7 @@ class SaveMapViewController: NSViewController {
             alert.messageText = "Error"
             alert.informativeText = "Title, tags and description are required fields"
             alert.addButton(withTitle: "OK")
-            alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+            alert.beginSheetModal(for: self.view.window!)
             return
         }
         

--- a/arcgis-runtime-samples-macos/Maps/Identify layers/IdentifyLayersViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Identify layers/IdentifyLayersViewController.swift
@@ -155,6 +155,6 @@ class IdentifyLayersViewController: NSViewController, AGSGeoViewTouchDelegate {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackageCellView.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackageCellView.swift
@@ -105,6 +105,6 @@ class MapPackageCellView: NSTableCellView, NSCollectionViewDataSource, NSCollect
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -339,7 +339,7 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }
 

--- a/arcgis-runtime-samples-macos/Maps/Take screenshot/TakeScreenshotViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Take screenshot/TakeScreenshotViewController.swift
@@ -121,6 +121,6 @@ class TakeScreenshotViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Route & Directions/Find route/FindRouteViewController.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Find route/FindRouteViewController.swift
@@ -193,6 +193,6 @@ class FindRouteViewController: NSViewController {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
@@ -235,6 +235,6 @@ class FindServiceAreaInteractiveVC: NSViewController, AGSGeoViewTouchDelegate {
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/RouteAroundBarriersVC.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/RouteAroundBarriersVC.swift
@@ -265,6 +265,6 @@ class RouteAroundBarriersVC: NSViewController, AGSGeoViewTouchDelegate, Directio
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }

--- a/arcgis-runtime-samples-macos/Search/Find address/FindAddressViewController.swift
+++ b/arcgis-runtime-samples-macos/Search/Find address/FindAddressViewController.swift
@@ -176,6 +176,6 @@ class FindAddressViewController: NSViewController, AGSGeoViewTouchDelegate, NSTe
         let alert = NSAlert()
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.beginSheetModal(for: self.view.window!, completionHandler: nil)
+        alert.beginSheetModal(for: self.view.window!)
     }
 }


### PR DESCRIPTION
The default value of `nil` was being used in almost all cases.

This change makes it easier to find uses of `AGSGeoView` handlers.