### PR TITLE
Map Drawing Status: Use KeyPath-based observation

### DIFF
--- a/arcgis-runtime-samples-macos/Maps/Display drawing status/DrawingStatusViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Display drawing status/DrawingStatusViewController.swift
@@ -24,6 +24,8 @@ class DrawingStatusViewController: NSViewController {
     @IBOutlet private var progressIndicator:NSProgressIndicator!
     
     private var map:AGSMap!
+    /// The observation of the map view's draw status.
+    private var drawStatusObservation: NSKeyValueObservation?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,20 +49,15 @@ class DrawingStatusViewController: NSViewController {
     
     override func viewWillAppear() {
         super.viewWillAppear()
-        
-        mapView.addObserver(self, forKeyPath: #keyPath(AGSGeoView.drawStatus), options: .initial, context: nil)
-    }
-    
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        DispatchQueue.main.async { [weak self] in
-            guard let strongSelf = self else { return }
-            strongSelf.activityIndicatorView.isHidden = strongSelf.mapView.drawStatus == .completed
+        drawStatusObservation = mapView.observe(\.drawStatus, options: .initial) { [weak self] (mapView, _) in
+            DispatchQueue.main.async {
+                self?.activityIndicatorView.isHidden = mapView.drawStatus == .completed
+            }
         }
     }
     
     override func viewDidDisappear() {
         super.viewDidDisappear()
-        
-        mapView.removeObserver(self, forKeyPath: #keyPath(AGSGeoView.drawStatus))
+        drawStatusObservation = nil
     }
 }


### PR DESCRIPTION
This brings the sample more in line with the corresponding iOS [implementation](https://github.com/Esri/arcgis-runtime-samples-ios/blob/v.next/arcgis-ios-sdk-samples/Maps/Display%20drawing%20status/MapViewDrawStatusViewController.swift).

It is the counterpart to this PR: 
https://github.com/Esri/arcgis-runtime-samples-ios/pull/449