### PR TITLE
Changes class-only protocols to inherit from AnyObject rather than class

### DIFF
--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/CollectionViewController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/CollectionViewController.swift
@@ -34,7 +34,7 @@ class CollectionViewItem: NSCollectionViewItem {
     
 }
 
-protocol CollectionViewControllerDelegate: class {
+protocol CollectionViewControllerDelegate: AnyObject {
     
     func collectionViewController(_ collectionViewController:CollectionViewController, didSelectSampleNode node:Node)
 }

--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/SuggestionsViewController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/SuggestionsViewController.swift
@@ -16,7 +16,7 @@
 
 import Cocoa
 
-protocol SuggestionsVCDelegate: class {
+protocol SuggestionsVCDelegate: AnyObject {
     
     func suggestionsViewController(_ suggestionsViewController: SuggestionsViewController, didSelectSuggestion suggestion: String)
 }

--- a/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/FeatureTemplatePickerVC.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/FeatureTemplatePickerVC.swift
@@ -23,7 +23,7 @@ class FeatureTemplateInfo {
     var featureLayer:AGSFeatureLayer!
 }
 
-protocol FeatureTemplatePickerVCDelegate:class {
+protocol FeatureTemplatePickerVCDelegate: AnyObject {
     
     func featureTemplatePickerVC(_ featureTemplatePickerVC:FeatureTemplatePickerVC, didSelectFeatureTemplate template:AGSFeatureTemplate, forFeatureLayer featureLayer:AGSFeatureLayer)
     

--- a/arcgis-runtime-samples-macos/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
+++ b/arcgis-runtime-samples-macos/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
@@ -16,7 +16,7 @@
 
 import Cocoa
 
-protocol VectorStylesVCDelegate: class {
+protocol VectorStylesVCDelegate: AnyObject {
     
     func vectorStylesViewController(_ vectorStylesViewController: VectorStylesViewController, didSelectItemWithID itemID:String)
     

--- a/arcgis-runtime-samples-macos/Layers/Change sublayer visibility/SublayerCellView.swift
+++ b/arcgis-runtime-samples-macos/Layers/Change sublayer visibility/SublayerCellView.swift
@@ -16,7 +16,7 @@
 
 import Cocoa
 
-protocol SublayerCellViewDelegate:class {
+protocol SublayerCellViewDelegate: AnyObject {
     func sublayerCellView(_ sublayerCellView:SublayerCellView, didToggleVisibility visible:Bool)
 }
 

--- a/arcgis-runtime-samples-macos/Maps/Create and save a map/CreateOptionsViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Create and save a map/CreateOptionsViewController.swift
@@ -17,7 +17,7 @@
 import Cocoa
 import ArcGIS
 
-protocol CreateOptionsVCDelegate:class {
+protocol CreateOptionsVCDelegate: AnyObject {
     func createOptionsViewController(_ createOptionsViewController:CreateOptionsViewController, didSelectBasemap basemap:AGSBasemap, layers:[AGSLayer]?)
 }
 

--- a/arcgis-runtime-samples-macos/Maps/Create and save a map/SaveMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Create and save a map/SaveMapViewController.swift
@@ -16,7 +16,7 @@
 
 import Cocoa
 
-protocol SaveMapVCDelegate:class {
+protocol SaveMapVCDelegate: AnyObject {
     
     func saveMapViewController(_ saveMapViewController:SaveMapViewController, didInitiateSaveWithTitle title:String, tags:[String], itemDescription:String?)
     

--- a/arcgis-runtime-samples-macos/Maps/Manage operational layers/AddedLayerCellView.swift
+++ b/arcgis-runtime-samples-macos/Maps/Manage operational layers/AddedLayerCellView.swift
@@ -16,7 +16,7 @@
 
 import Cocoa
 
-protocol AddedLayerCellViewDelegate:class {
+protocol AddedLayerCellViewDelegate: AnyObject {
     
     func addedLayerCellViewWantsToDelete(_ addedLayerCellView:AddedLayerCellView)
 }

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackageCellView.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackageCellView.swift
@@ -17,7 +17,7 @@
 import Cocoa
 import ArcGIS
 
-protocol MapPackageCellDelegate:class {
+protocol MapPackageCellDelegate: AnyObject {
     
     func mapPackageCellView(_ mapPackageCellView:MapPackageCellView, didSelectMap map:AGSMap)
 }

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackagesListVC.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackagesListVC.swift
@@ -17,7 +17,7 @@
 import Cocoa
 import ArcGIS
 
-protocol MapPackagesListVCDelegate: class {
+protocol MapPackagesListVCDelegate: AnyObject {
     
     func mapPackagesListVC(_ mapPackagesListVC: MapPackagesListVC, wantsToShowMap map: AGSMap, withLocatorTask locatorTask: AGSLocatorTask?)
 }

--- a/arcgis-runtime-samples-macos/Maps/Open an existing map/ExistingMapsListViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Open an existing map/ExistingMapsListViewController.swift
@@ -16,7 +16,7 @@
 
 import Cocoa
 
-protocol ExistingMapsListViewControllerDelegate: class {
+protocol ExistingMapsListViewControllerDelegate: AnyObject {
     func existingMapsListViewController(_:ExistingMapsListViewController, didSelectItemAt index: Int)
 }
 

--- a/arcgis-runtime-samples-macos/Maps/Read a geopackage/GPKGLayerTableCell.swift
+++ b/arcgis-runtime-samples-macos/Maps/Read a geopackage/GPKGLayerTableCell.swift
@@ -14,7 +14,7 @@
 
 import ArcGIS
 
-protocol GPKGLayerTableCellDelegate: class {
+protocol GPKGLayerTableCellDelegate: AnyObject {
     func removeLayerFromMap(cell:GPKGLayerTableCell)
 }
 

--- a/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/DirectionsListViewController.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/DirectionsListViewController.swift
@@ -17,7 +17,7 @@
 import Cocoa
 import ArcGIS
 
-protocol DirectionsListVCDelegate:class {
+protocol DirectionsListVCDelegate: AnyObject {
     
     func directionsListViewController(_ directionsListViewController:DirectionsListViewController, didSelectDirectionManuever directionManeuver:AGSDirectionManeuver)
     


### PR DESCRIPTION
As per [best practices](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID281), I changed protocols limited to classes to inherit from AnyObject, as in `protocol MyObjectDelegate: AnyObject { … }`, rather than from class, as in `protocol MyObjectDelegate: class { … }`.