### PR TITLE
Main window title bar and toolbar design improvements

### DIFF
--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -662,7 +662,7 @@
                 <windowController id="B8D-0N-5wS" customClass="WindowController" customModule="arcgis_runtime_samples_macos" customModuleProvider="target" sceneMemberID="viewController">
                     <window key="window" title="ArcGIS Runtime Samples" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titleVisibility="hidden" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" texturedBackground="YES"/>
-                        <rect key="contentRect" x="196" y="240" width="1000" height="300"/>
+                        <rect key="contentRect" x="196" y="240" width="793" height="300"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
                         <value key="minSize" type="size" width="800" height="300"/>
                         <toolbar key="toolbar" implicitIdentifier="CE0F7EFC-B7DB-4E9E-9B18-F711D9D5B0CB" autosavesConfiguration="NO" allowsUserCustomization="NO" displayMode="iconOnly" sizeMode="regular" id="2cM-oC-JOT">
@@ -672,7 +672,7 @@
                                 <toolbarItem implicitItemIdentifier="643CC669-7FBF-4E90-9C64-D504404B7AA4" label="" paletteLabel="" sizingBehavior="auto" id="EM3-m8-0vq" userLabel="Toolbar Item - Search Field">
                                     <nil key="toolTip"/>
                                     <searchField key="view" toolTip="Search Sample" wantsLayer="YES" verticalHuggingPriority="750" id="Mv2-JN-rDN">
-                                        <rect key="frame" x="0.0" y="14" width="250" height="22"/>
+                                        <rect key="frame" x="0.0" y="14" width="230" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" placeholderString=" Search" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" sendsWholeSearchString="YES" id="bIR-56-t8z">
                                             <font key="font" metaFont="cellTitle"/>
@@ -708,9 +708,9 @@
                                 <toolbarItem implicitItemIdentifier="202CDAD7-3A2A-4D75-9C0A-AFDE60E71A55" label="" paletteLabel="" sizingBehavior="auto" id="sRu-fy-9k2">
                                     <nil key="toolTip"/>
                                     <textField key="view" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="dNV-XY-eT4">
-                                        <rect key="frame" x="0.0" y="14" width="201" height="17"/>
+                                        <rect key="frame" x="0.0" y="14" width="225" height="17"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Native ArcGIS Runtime Samples" id="HEp-ai-Sq0">
+                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="ArcGIS Runtime SDK Sample Viewer" id="HEp-ai-Sq0">
                                             <font key="font" metaFont="titleBar"/>
                                             <color key="textColor" name="windowFrameTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -719,7 +719,11 @@
                                 </toolbarItem>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
-                                <toolbarItem reference="exl-JJ-tks"/>
+                                <toolbarItem reference="yOd-Gb-sxP"/>
+                                <toolbarItem reference="yOd-Gb-sxP"/>
+                                <toolbarItem reference="yOd-Gb-sxP"/>
+                                <toolbarItem reference="yOd-Gb-sxP"/>
+                                <toolbarItem reference="yOd-Gb-sxP"/>
                                 <toolbarItem reference="exl-JJ-tks"/>
                                 <toolbarItem reference="sRu-fy-9k2"/>
                                 <toolbarItem reference="exl-JJ-tks"/>
@@ -751,7 +755,7 @@
                     </items>
                 </menu>
             </objects>
-            <point key="canvasLocation" x="75" y="235"/>
+            <point key="canvasLocation" x="-28.5" y="235"/>
         </scene>
         <!--Main View Controller-->
         <scene sceneID="aFZ-l8-okz">

--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -672,9 +672,9 @@
                                 <toolbarItem implicitItemIdentifier="643CC669-7FBF-4E90-9C64-D504404B7AA4" label="" paletteLabel="" sizingBehavior="auto" id="EM3-m8-0vq" userLabel="Toolbar Item - Search Field">
                                     <nil key="toolTip"/>
                                     <searchField key="view" toolTip="Search Sample" wantsLayer="YES" verticalHuggingPriority="750" id="Mv2-JN-rDN">
-                                        <rect key="frame" x="0.0" y="14" width="400" height="22"/>
+                                        <rect key="frame" x="0.0" y="14" width="250" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" placeholderString=" Search samples" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" sendsWholeSearchString="YES" id="bIR-56-t8z">
+                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" placeholderString=" Search" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" sendsWholeSearchString="YES" id="bIR-56-t8z">
                                             <font key="font" metaFont="cellTitle"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -705,11 +705,25 @@
                                         </contentFilters>
                                     </progressIndicator>
                                 </toolbarItem>
+                                <toolbarItem implicitItemIdentifier="202CDAD7-3A2A-4D75-9C0A-AFDE60E71A55" label="" paletteLabel="" sizingBehavior="auto" id="sRu-fy-9k2">
+                                    <nil key="toolTip"/>
+                                    <textField key="view" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="dNV-XY-eT4">
+                                        <rect key="frame" x="0.0" y="14" width="201" height="17"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Native ArcGIS Runtime Samples" id="HEp-ai-Sq0">
+                                            <font key="font" metaFont="titleBar"/>
+                                            <color key="textColor" name="windowFrameTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </toolbarItem>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
                                 <toolbarItem reference="exl-JJ-tks"/>
-                                <toolbarItem reference="EM3-m8-0vq"/>
                                 <toolbarItem reference="exl-JJ-tks"/>
+                                <toolbarItem reference="sRu-fy-9k2"/>
+                                <toolbarItem reference="exl-JJ-tks"/>
+                                <toolbarItem reference="EM3-m8-0vq"/>
                             </defaultToolbarItems>
                         </toolbar>
                         <connections>

--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -660,7 +660,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" customClass="WindowController" customModule="arcgis_runtime_samples_macos" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="ArcGIS Runtime Sample Viewer for OS X - Quartz Beta 1" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="ArcGIS Runtime Samples" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titleVisibility="hidden" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" texturedBackground="YES"/>
                         <rect key="contentRect" x="196" y="240" width="1000" height="300"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
@@ -669,30 +669,12 @@
                             <allowedToolbarItems>
                                 <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="yOd-Gb-sxP"/>
                                 <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="exl-JJ-tks"/>
-                                <toolbarItem implicitItemIdentifier="904B78FA-48FD-43E1-8FA4-92C794A81ECA" label="" paletteLabel="Custom View" id="qFL-bD-HLE">
+                                <toolbarItem implicitItemIdentifier="643CC669-7FBF-4E90-9C64-D504404B7AA4" label="" paletteLabel="" sizingBehavior="auto" id="EM3-m8-0vq" userLabel="Toolbar Item - Search Field">
                                     <nil key="toolTip"/>
-                                    <size key="minSize" width="207" height="23"/>
-                                    <size key="maxSize" width="207" height="24"/>
-                                    <segmentedControl key="view" verticalHuggingPriority="750" id="I1b-zQ-FfJ">
-                                        <rect key="frame" x="0.0" y="14" width="207" height="24"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="selectOne" id="aPX-7s-PPn">
-                                            <font key="font" metaFont="cellTitle"/>
-                                            <segments>
-                                                <segment label="Objective C" width="100" selected="YES"/>
-                                                <segment label="Swift" width="100" tag="1"/>
-                                            </segments>
-                                        </segmentedCell>
-                                    </segmentedControl>
-                                </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="643CC669-7FBF-4E90-9C64-D504404B7AA4" label="" paletteLabel="" id="EM3-m8-0vq" userLabel="Toolbar Item - Search Field">
-                                    <nil key="toolTip"/>
-                                    <size key="minSize" width="50" height="22"/>
-                                    <size key="maxSize" width="240" height="22"/>
                                     <searchField key="view" toolTip="Search Sample" wantsLayer="YES" verticalHuggingPriority="750" id="Mv2-JN-rDN">
-                                        <rect key="frame" x="0.0" y="14" width="240" height="22"/>
+                                        <rect key="frame" x="0.0" y="14" width="400" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" placeholderString=" Search" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" sendsWholeSearchString="YES" id="bIR-56-t8z">
+                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" placeholderString=" Search samples" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" sendsWholeSearchString="YES" id="bIR-56-t8z">
                                             <font key="font" metaFont="cellTitle"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -703,50 +685,6 @@
                                             <outlet property="menu" destination="MPl-sb-Tvx" id="Jga-Ag-Tqy"/>
                                         </connections>
                                     </searchField>
-                                </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="709697F6-0ECC-472A-B2B5-5F28CA085DB2" label="" paletteLabel="" image="HomeIcon" id="EmN-n9-3Pb" userLabel="Toolbar Item - Home">
-                                    <nil key="toolTip"/>
-                                    <size key="minSize" width="32" height="32"/>
-                                    <size key="maxSize" width="32" height="32"/>
-                                    <button key="view" toolTip="Home" id="c4L-3e-SBX">
-                                        <rect key="frame" x="0.0" y="14" width="32" height="32"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="HomeIcon" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="Phj-5h-Fvk">
-                                            <behavior key="behavior" lightByContents="YES"/>
-                                            <font key="font" metaFont="system" size="10"/>
-                                        </buttonCell>
-                                    </button>
-                                </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="9F1D127F-8175-4972-BF95-77DE728FBF22" label="" paletteLabel="" id="TmG-JT-s96" userLabel="Toolbar Item - Segmented Control">
-                                    <nil key="toolTip"/>
-                                    <size key="minSize" width="300" height="24"/>
-                                    <size key="maxSize" width="304" height="25"/>
-                                    <segmentedControl key="view" verticalHuggingPriority="750" id="Qiw-bf-h5J">
-                                        <rect key="frame" x="0.0" y="14" width="304" height="25"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="bdb-Yb-eTh">
-                                            <font key="font" metaFont="system"/>
-                                            <segments>
-                                                <segment label="Live Sample" toolTip="Live Sample" width="100" selected="YES"/>
-                                                <segment label="Source Code" toolTip="Source Code" width="98" tag="1"/>
-                                                <segment label="Description" toolTip="Description" width="98"/>
-                                            </segments>
-                                        </segmentedCell>
-                                    </segmentedControl>
-                                </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="A6EC4DFA-D0EC-4BD5-A0B6-D924376D86C7" label="" paletteLabel="" id="ID2-mU-TbV">
-                                    <nil key="toolTip"/>
-                                    <size key="minSize" width="38" height="27"/>
-                                    <size key="maxSize" width="237" height="30"/>
-                                    <textField key="view" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="L53-ze-dGZ">
-                                        <rect key="frame" x="0.0" y="14" width="236" height="27"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="ArcGIS Runtime macOS samples" id="6Sh-lM-fKR">
-                                            <font key="font" metaFont="system" size="14"/>
-                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
                                 </toolbarItem>
                                 <toolbarItem implicitItemIdentifier="C41AB23B-0874-4E64-8AB4-0F6B53F7643D" label="" paletteLabel="" tag="-1" id="LRI-le-gnh">
                                     <nil key="toolTip"/>
@@ -770,11 +708,8 @@
                             </allowedToolbarItems>
                             <defaultToolbarItems>
                                 <toolbarItem reference="exl-JJ-tks"/>
-                                <toolbarItem reference="exl-JJ-tks"/>
-                                <toolbarItem reference="ID2-mU-TbV"/>
-                                <toolbarItem reference="exl-JJ-tks"/>
-                                <toolbarItem reference="LRI-le-gnh"/>
                                 <toolbarItem reference="EM3-m8-0vq"/>
+                                <toolbarItem reference="exl-JJ-tks"/>
                             </defaultToolbarItems>
                         </toolbar>
                         <connections>
@@ -1119,7 +1054,4 @@
             <point key="canvasLocation" x="784" y="1299"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="HomeIcon" width="30" height="30"/>
-    </resources>
 </document>

--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/WindowController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/WindowController.swift
@@ -45,10 +45,6 @@ class WindowController: NSWindowController, NSSearchFieldDelegate, NSWindowDeleg
         super.windowDidLoad()
     
         self.window?.delegate = self
-        self.window?.isMovableByWindowBackground = false
-        self.window?.titleVisibility = .hidden
-        self.window?.titlebarAppearsTransparent = true
-        self.window?.backgroundColor = .primaryBlue
         
         self.suggestionsWindowController = self.storyboard?.instantiateController(withIdentifier: "SuggestionsWindowController") as? NSWindowController
         self.suggestionsViewController = self.suggestionsWindowController.contentViewController as? SuggestionsViewController
@@ -122,10 +118,12 @@ class WindowController: NSWindowController, NSSearchFieldDelegate, NSWindowDeleg
             let mainWindow = NSApplication.shared.mainWindow!
             
             //frame calculations
-            let originX = mainWindow.frame.origin.x + mainWindow.frame.width - self.searchField.frame.width - 6
-            let originY:CGFloat = mainWindow.frame.origin.y + mainWindow.frame.height - self.searchField.frame.height - suggestionsWindow.frame.height - 10
+            
+            let originX = mainWindow.frame.origin.x + mainWindow.contentView!.convert(searchField.bounds.origin, from: searchField).x
+            
+            let originY:CGFloat = mainWindow.frame.maxY - searchField.frame.height - suggestionsWindow.frame.height - 10
             let frameOrigin = NSPoint(x: originX, y: originY)
-            let frameSize = NSSize(width: self.searchField.frame.width, height: suggestionsWindow.frame.height)
+            let frameSize = NSSize(width: searchField.frame.width, height: suggestionsWindow.frame.height)
             
             //set frame
             suggestionsWindow.setFrame(NSRect(origin: frameOrigin, size: frameSize), display: true)


### PR DESCRIPTION
- Fixes an issue where sheets would open from above the window's title bar rather than below it
- Removes the non-standard window background color
- Removes several unused toolbar items from the main window in the storyboard
- Aligns the search suggestions window below the search field no matter where the containing toolbar item is placed