### PR TITLE
Removes calls to the soon-to-be-deprecated selectionWidth property

### DIFF
--- a/arcgis-runtime-samples-macos/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -49,9 +49,6 @@ class DeleteFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate, A
         //create a feature layer using the service feature table
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
-        //feature layer selection settings
-        self.featureLayer.selectionWidth = 5
-        
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)
     }

--- a/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
@@ -49,9 +49,6 @@ class EditFeaturesConnectedVC: NSViewController, AGSGeoViewTouchDelegate, AGSPop
         self.featureLayer = AGSFeatureLayer(featureTable: featureTable)
         self.map.operationalLayers.add(featureLayer)
         
-        //feature layer selection settings
-        self.featureLayer.selectionWidth = 4
-        
         //initialize sketch editor and assign to map view
         self.sketchEditor = AGSSketchEditor()
         self.mapView.sketchEditor = self.sketchEditor

--- a/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
@@ -40,9 +40,6 @@ class FeatureLayerQueryVC: NSViewController, NSTextFieldDelegate {
         //create feature layer using this feature table
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
-        //feature layer selection settings
-        self.featureLayer.selectionWidth = 4
-        
         //set a new renderer
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .black, width: 1)
         let fillSymbol = AGSSimpleFillSymbol(style: .solid, color: NSColor.yellow.withAlphaComponent(0.5), outline: lineSymbol)


### PR DESCRIPTION
I somehow missed this before when updating to the new selection API.