### PR TITLE
Re-adds and refactors the progress indicator

### DIFF
--- a/arcgis-runtime-samples-macos/Analysis/Analyze hotspots/HotspotsViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Analyze hotspots/HotspotsViewController.swift
@@ -77,7 +77,7 @@ class HotspotsViewController: NSViewController {
         self.geoprocessingJob = self.geoprocessingTask.geoprocessingJob(with: params)
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //start job
         self.geoprocessingJob.start(statusHandler: { (status: AGSJobStatus) in
@@ -85,7 +85,7 @@ class HotspotsViewController: NSViewController {
         }) { [weak self] (result: AGSGeoprocessingResult?, error: Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             //enable apply button
             self?.applyButton.isEnabled = true

--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -86,13 +86,13 @@ class ViewshedGeoprocessingViewController: NSViewController, AGSGeoViewTouchDele
         newFeature.geometry = point
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //add the new feature to the feature collection table
         featureCollectionTable.add(newFeature) { [weak self] (error: Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: error.localizedDescription)
@@ -117,7 +117,7 @@ class ViewshedGeoprocessingViewController: NSViewController, AGSGeoViewTouchDele
         self.geoprocessingJob = self.geoprocessingTask.geoprocessingJob(with: params)
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //start the job
         self.geoprocessingJob.start(statusHandler: { (status: AGSJobStatus) in
@@ -127,7 +127,7 @@ class ViewshedGeoprocessingViewController: NSViewController, AGSGeoViewTouchDele
         }, completion: { [weak self] (result: AGSGeoprocessingResult?, error: Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard error == nil else {
                 if (error! as NSError).code != NSUserCancelledError {

--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -686,23 +686,11 @@
                                         </connections>
                                     </searchField>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="C41AB23B-0874-4E64-8AB4-0F6B53F7643D" label="" paletteLabel="" tag="-1" id="LRI-le-gnh">
+                                <toolbarItem implicitItemIdentifier="0DB37989-C4DA-4360-BB81-F400173A4A68" label="" paletteLabel="" tag="-1" sizingBehavior="auto" id="U3V-1E-r9n">
                                     <nil key="toolTip"/>
-                                    <size key="minSize" width="16" height="16"/>
-                                    <size key="maxSize" width="32" height="32"/>
-                                    <progressIndicator key="view" hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="hep-iw-wZ1">
+                                    <progressIndicator key="view" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="eUx-FW-oJk">
                                         <rect key="frame" x="0.0" y="14" width="16" height="16"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <contentFilters>
-                                            <ciFilter name="CIColorControls">
-                                                <configuration>
-                                                    <real key="inputBrightness" value="1"/>
-                                                    <real key="inputContrast" value="1"/>
-                                                    <null key="inputImage"/>
-                                                    <real key="inputSaturation" value="1"/>
-                                                </configuration>
-                                            </ciFilter>
-                                        </contentFilters>
                                     </progressIndicator>
                                 </toolbarItem>
                                 <toolbarItem implicitItemIdentifier="202CDAD7-3A2A-4D75-9C0A-AFDE60E71A55" label="" paletteLabel="" sizingBehavior="auto" id="sRu-fy-9k2">
@@ -719,7 +707,7 @@
                                 </toolbarItem>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
-                                <toolbarItem reference="yOd-Gb-sxP"/>
+                                <toolbarItem reference="U3V-1E-r9n"/>
                                 <toolbarItem reference="yOd-Gb-sxP"/>
                                 <toolbarItem reference="yOd-Gb-sxP"/>
                                 <toolbarItem reference="yOd-Gb-sxP"/>
@@ -735,7 +723,7 @@
                         </connections>
                     </window>
                     <connections>
-                        <outlet property="progressIndicator" destination="hep-iw-wZ1" id="Wt8-IP-QV4"/>
+                        <outlet property="progressIndicator" destination="eUx-FW-oJk" id="Qm6-qt-xpl"/>
                         <outlet property="searchField" destination="Mv2-JN-rDN" id="b4z-so-mW6"/>
                         <segue destination="5Rb-wc-9vd" kind="relationship" relationship="window.shadowedContentViewController" id="yCm-lG-J0c"/>
                     </connections>

--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/WindowController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/WindowController.swift
@@ -16,19 +16,17 @@
 
 import Cocoa
 
-extension NSWindow {
+extension NSApplication {
     //MARK: - Progres indicator
     
     func showProgressIndicator() {
-        if let controller = self.windowController as? WindowController {
-            controller.showProgressIndicator()
-        }
+        let controller = windows.compactMap { return $0.windowController as? WindowController }.first
+        controller?.showProgressIndicator()
     }
     
     func hideProgressIndicator() {
-        if let controller = self.windowController as? WindowController {
-            controller.hideProgressIndicator()
-        }
+        let controller = windows.compactMap { return $0.windowController as? WindowController }.first
+        controller?.hideProgressIndicator()
     }
 }
 
@@ -50,18 +48,16 @@ class WindowController: NSWindowController, NSSearchFieldDelegate, NSWindowDeleg
         self.suggestionsViewController = self.suggestionsWindowController.contentViewController as? SuggestionsViewController
         self.suggestionsViewController.delegate = self
         
-        //progress indicator
-        self.progressIndicator.startAnimation(nil)
     }
     
     //MARK: - Progres indicator
     
     func showProgressIndicator() {
-        self.progressIndicator.isHidden = false
+        progressIndicator.startAnimation(nil)
     }
 
     func hideProgressIndicator() {
-        self.progressIndicator.isHidden = true
+        progressIndicator.stopAnimation(nil)
     }
     
     //MARK: - NSSearchFieldDelegate

--- a/arcgis-runtime-samples-macos/Display information/Identify graphics/GOIdentifyViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Identify graphics/GOIdentifyViewController.swift
@@ -72,12 +72,12 @@ class GOIdentifyViewController: NSViewController, AGSGeoViewTouchDelegate {
         let tolerance:Double = 4
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.mapView.identify(self.graphicsOverlay, screenPoint: screenPoint, tolerance: tolerance, returnPopupsOnly: false) { (result: AGSIdentifyGraphicsOverlayResult) in
             
             //hide progress indicator
-            self.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = result.error {
                 print("error while identifying :: \(error.localizedDescription)")

--- a/arcgis-runtime-samples-macos/Display information/Show legend/ShowLegendViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Show legend/ShowLegendViewController.swift
@@ -71,12 +71,12 @@ class ShowLegendViewController: NSViewController, NSOutlineViewDataSource, NSOut
                 orderArray.append(layer)
                 
                 //show progress indicator
-                view.window?.showProgressIndicator()
+                NSApp.showProgressIndicator()
                 
                 layer.fetchLegendInfos { [weak self] (legendInfos: [AGSLegendInfo]?, error: Error?) -> Void in
                     guard let strongSelf = self else { return }
                     //hide progress indicator
-                    strongSelf.view.window?.hideProgressIndicator()
+                    NSApp.hideProgressIndicator()
                     
                     if let error = error {
                         print(error)

--- a/arcgis-runtime-samples-macos/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -49,7 +49,7 @@ class AddFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate {
     
     func addFeature(at point:AGSPoint) {
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //normalize geometry
         let normalizedGeometry = AGSGeometryEngine.normalizeCentralMeridian(of: point)!
@@ -63,7 +63,7 @@ class AddFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate {
         self.featureTable.add(feature) { [weak self] (error: Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: "Error while adding feature :: \(error.localizedDescription)")
@@ -78,11 +78,11 @@ class AddFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate {
     func applyEdits() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.featureTable.applyEdits { [weak self] (featureEditResults: [AGSFeatureEditResult]?, error: Error?) -> Void in
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: "Error while applying edits :: \(error.localizedDescription)")

--- a/arcgis-runtime-samples-macos/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -55,11 +55,11 @@ class DeleteFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate, A
     
     func deleteFeature(_ feature:AGSFeature) {
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.featureTable.delete(feature) { [weak self] (error: Error?) -> Void in
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: "Error while deleting feature : \(error.localizedDescription)")
@@ -73,12 +73,12 @@ class DeleteFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate, A
     
     func applyEdits() {
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.featureTable.applyEdits { [weak self] (featureEditResults: [AGSFeatureEditResult]?, error: Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: "Error while applying edits :: \(error.localizedDescription)")
@@ -102,12 +102,12 @@ class DeleteFeaturesViewController: NSViewController, AGSGeoViewTouchDelegate, A
         self.mapView.callout.dismiss()
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.lastQuery = self.mapView.identifyLayer(self.featureLayer, screenPoint: screenPoint, tolerance: 5, returnPopupsOnly: false, maximumResults: 1) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = identifyLayerResult.error {
                 self?.showAlert(messageText: "Error", informativeText: error.localizedDescription)

--- a/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
@@ -59,12 +59,12 @@ class EditFeaturesConnectedVC: NSViewController, AGSGeoViewTouchDelegate, AGSPop
     
     func applyEdits() {
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         (self.featureLayer.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (result:[AGSFeatureEditResult]?, error:Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: "Error while applying edits :: \(error.localizedDescription)")
@@ -83,12 +83,12 @@ class EditFeaturesConnectedVC: NSViewController, AGSGeoViewTouchDelegate, AGSPop
         }
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.lastQuery = self.mapView.identifyLayer(self.featureLayer, screenPoint: screenPoint, tolerance: 5, returnPopupsOnly: false, maximumResults: 10) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = identifyLayerResult.error {
                 self?.showAlert(messageText: "Error", informativeText: "Error while identifying features :: \(error.localizedDescription)")

--- a/arcgis-runtime-samples-macos/Features/Add delete related features/AddDeleteRelatedFeaturesVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Add delete related features/AddDeleteRelatedFeaturesVC.swift
@@ -91,7 +91,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         }
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //keep for later use
         self.relationshipInfo = relationshipInfo
@@ -106,7 +106,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         self.parksFeatureTable.queryRelatedFeatures(for: self.selectedPark, parameters: parameters) { [weak self] (results:[AGSRelatedFeatureQueryResult]?, error:Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard error == nil else {
                 
@@ -135,7 +135,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
     private func addRelatedFeature() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //get related table using relationshipInfo
         let relatedTable = self.parksFeatureTable.relatedTables(with: self.relationshipInfo)![0] as! AGSServiceFeatureTable
@@ -150,7 +150,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         relatedTable.add(feature) { [weak self] (error) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard error == nil else {
                 
@@ -167,7 +167,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
     private func deleteRelatedFeature(_ feature: AGSFeature) {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //get related table using relationshipInfo
         let relatedTable = self.parksFeatureTable.relatedTables(with: self.relationshipInfo)![0] as! AGSServiceFeatureTable
@@ -176,7 +176,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         relatedTable.delete(feature) { [weak self] (error) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard error == nil else {
                 
@@ -193,7 +193,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
     private func applyEdits() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //get the related table using the relationshipInfo
         let relatedTable = self.parksFeatureTable.relatedTables(with: self.relationshipInfo)![0] as! AGSServiceFeatureTable
@@ -201,7 +201,7 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         relatedTable.applyEdits { [weak self] (results:[AGSFeatureEditResult]?, error:Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard error == nil else {
                 //show error
@@ -233,13 +233,13 @@ class AddDeleteRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, AGS
         self.featureTextField.stringValue = ""
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //identify feature at tapped location
         self.identifyCancelable = self.mapView.identifyLayer(self.parksFeatureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (result: AGSIdentifyLayerResult) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard result.error == nil else {
                 

--- a/arcgis-runtime-samples-macos/Features/Feature collection layer (query)/FeatureCollectionLayerQueryVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature collection layer (query)/FeatureCollectionLayerQueryVC.swift
@@ -42,13 +42,13 @@ class FeatureCollectionLayerQueryVC: NSViewController {
         queryParams.whereClause = "1=1"
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //query feature from the table
         self.featureTable.queryFeatures(with: queryParams) { [weak self] (queryResult: AGSFeatureQueryResult?, error: Error?) in
         
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 print(error)

--- a/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Feature layer query/FeatureLayerQueryVC.swift
@@ -59,7 +59,7 @@ class FeatureLayerQueryVC: NSViewController, NSTextFieldDelegate {
         }
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         let queryParams = AGSQueryParameters()
         queryParams.whereClause = "upper(STATE_NAME) LIKE '%\(state.uppercased())%'"
@@ -67,7 +67,7 @@ class FeatureLayerQueryVC: NSViewController, NSTextFieldDelegate {
         self.featureTable.queryFeatures(with: queryParams) { [weak self] (result:AGSFeatureQueryResult?, error:Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 //show error

--- a/arcgis-runtime-samples-macos/Features/Generate geodatabase/GenerateGeodatabaseVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Generate geodatabase/GenerateGeodatabaseVC.swift
@@ -96,14 +96,14 @@ class GenerateGeodatabaseVC: NSViewController {
         self.generateButton.isEnabled = false
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //generate default param to contain all layers in the service
         self.syncTask.defaultGenerateGeodatabaseParameters(withExtent: self.frameToExtent()) { [weak self] (params: AGSGenerateGeodatabaseParameters?, error: Error?) in
             if let params = params, let weakSelf = self {
                 
                 //hide progress indicator
-                self?.view.window?.hideProgressIndicator()
+                NSApp.hideProgressIndicator()
                 
                 //don't include attachments to minimze the geodatabae size
                 params.returnAttachments = false
@@ -119,7 +119,7 @@ class GenerateGeodatabaseVC: NSViewController {
                 weakSelf.generateJob = weakSelf.syncTask.generateJob(with: params, downloadFileURL: URL(string: fullPath)!)
                 
                 //show progress indicator
-                self?.view.window?.showProgressIndicator()
+                NSApp.showProgressIndicator()
                 
                 //kick off the job
                 weakSelf.generateJob.start(statusHandler: { (status: AGSJobStatus) -> Void in
@@ -127,7 +127,7 @@ class GenerateGeodatabaseVC: NSViewController {
                 }) { [weak self] (object: AnyObject?, error: Error?) -> Void in
                     
                     //hide progress indicator
-                    self?.view.window?.hideProgressIndicator()
+                    NSApp.hideProgressIndicator()
                     
                     if let error = error {
                         self?.showAlert(messageText: "Error", informativeText: error.localizedDescription)

--- a/arcgis-runtime-samples-macos/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-runtime-samples-macos/Features/List related features/ListRelatedFeaturesVC.swift
@@ -87,7 +87,7 @@ class ListRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, NSOutlin
     private func queryRelatedFeatures() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //reset table view till new query returns results
         self.results = nil
@@ -98,7 +98,7 @@ class ListRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, NSOutlin
         self.parksFeatureTable.queryRelatedFeatures(for: self.selectedPark) { [weak self] (results:[AGSRelatedFeatureQueryResult]?, error:Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 
@@ -134,13 +134,13 @@ class ListRelatedFeaturesVC: NSViewController, AGSGeoViewTouchDelegate, NSOutlin
         self.identifyCancelable?.cancel()
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //identify feature at tapped location
         self.identifyCancelable = self.mapView.identifyLayer(self.parksFeatureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (result: AGSIdentifyLayerResult) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = result.error {
                 

--- a/arcgis-runtime-samples-macos/Maps/Identify layers/IdentifyLayersViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Identify layers/IdentifyLayersViewController.swift
@@ -75,12 +75,12 @@ class IdentifyLayersViewController: NSViewController, AGSGeoViewTouchDelegate {
     
     private func identifyLayers(at screenPoint: CGPoint) {
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.mapView.identifyLayers(atScreenPoint: screenPoint, tolerance: 22, returnPopupsOnly: false, maximumResultsPerLayer: 10) { [weak self] (results: [AGSIdentifyLayerResult]?, error: Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: error.localizedDescription)

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackageCellView.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MapPackageCellView.swift
@@ -41,12 +41,12 @@ class MapPackageCellView: NSTableCellView, NSCollectionViewDataSource, NSCollect
     func loadMapPackage() {
         
         //show progress indicator
-        self.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.mapPackage.load { [weak self] (error:Error?) in
             
             //hide progress indicator
-            self?.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 //error

--- a/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -144,7 +144,7 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
         }
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //identify to check if a graphic is present
         //if yes, then show callout with geocoding
@@ -152,7 +152,7 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
         self.mapView.identify(self.markerGraphicsOverlay, screenPoint: screenPoint, tolerance: 5, returnPopupsOnly: false) { [weak self] (result:AGSIdentifyGraphicsOverlayResult) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = result.error {
                 self?.showAlert(messageText: "Error", informativeText: error.localizedDescription)
@@ -199,12 +199,12 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
         }
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.locatorTaskCancelable = self.locatorTask?.reverseGeocode(withLocation: point, parameters: self.reverseGeocodeParameters) { [weak self](results:[AGSGeocodeResult]?, error:Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 
@@ -249,13 +249,13 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
     private func getDefaultParameters() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //get the default parameters
         self.routeTask.defaultRouteParameters { [weak self] (params: AGSRouteParameters?, error: Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 
@@ -288,13 +288,13 @@ class MobileMapViewController: NSViewController, AGSGeoViewTouchDelegate, MapPac
         self.routeParameters.setStops(stops)
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //route
         self.routeTaskCancelable = self.routeTask.solveRoute(with: self.routeParameters) {[weak self] (routeResult:AGSRouteResult?, error:Error?) in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 //show error

--- a/arcgis-runtime-samples-macos/Maps/Take screenshot/TakeScreenshotViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Take screenshot/TakeScreenshotViewController.swift
@@ -55,13 +55,13 @@ class TakeScreenshotViewController: NSViewController {
         self.hideOverlayParentView()
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //the method on map view we can use to get the screenshot image
         self.mapView.exportImage { [weak self] (image:NSImage?, error:Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert("Error", informativeText: error.localizedDescription)

--- a/arcgis-runtime-samples-macos/Route & Directions/Find route/FindRouteViewController.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Find route/FindRouteViewController.swift
@@ -96,12 +96,12 @@ class FindRouteViewController: NSViewController {
     func getDefaultParameters() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.routeTask.defaultRouteParameters { [weak self] (parameters, error) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard error == nil else {
                 self?.showAlert(messageText: "Error", informativeText: error!.localizedDescription)
@@ -130,7 +130,7 @@ class FindRouteViewController: NSViewController {
         }
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //set parameters to return directions
         routeParameters.returnDirections = true
@@ -151,7 +151,7 @@ class FindRouteViewController: NSViewController {
         self.routeTask.solveRoute(with: routeParameters) { [weak self] (routeResult, error) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             guard let strongSelf = self else {
                 return

--- a/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/RouteAroundBarriersVC.swift
+++ b/arcgis-runtime-samples-macos/Route & Directions/Route around barriers/RouteAroundBarriersVC.swift
@@ -78,12 +78,12 @@ class RouteAroundBarriersVC: NSViewController, AGSGeoViewTouchDelegate, Directio
     func getDefaultParameters() {
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.routeTask.defaultRouteParameters { [weak self] (params: AGSRouteParameters?, error: Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: error.localizedDescription)
@@ -130,12 +130,12 @@ class RouteAroundBarriersVC: NSViewController, AGSGeoViewTouchDelegate, Directio
         self.routeParameters.setPolygonBarriers(barriers)
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         self.routeTask.solveRoute(with: self.routeParameters) { [weak self] (routeResult:AGSRouteResult?, error:Error?) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 self?.showAlert(messageText: "Error", informativeText: "\(error.localizedDescription) \((error as NSError).localizedFailureReason ?? "")")

--- a/arcgis-runtime-samples-macos/Search/Find address/FindAddressViewController.swift
+++ b/arcgis-runtime-samples-macos/Search/Find address/FindAddressViewController.swift
@@ -59,14 +59,14 @@ class FindAddressViewController: NSViewController, AGSGeoViewTouchDelegate, NSTe
         self.mapView.callout.dismiss()
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //perform geocode with input text
         locatorTask.geocode(withSearchText: text, parameters: geocodeParameters) { [weak self] (results: [AGSGeocodeResult]?, error: Error?) -> Void in
             guard let strongSelf = self else { return }
             
             //hide progress indicator
-            strongSelf.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = error {
                 strongSelf.showAlert("Error", informativeText: error.localizedDescription)
@@ -117,13 +117,13 @@ class FindAddressViewController: NSViewController, AGSGeoViewTouchDelegate, NSTe
         self.mapView.callout.dismiss()
         
         //show progress indicator
-        self.view.window?.showProgressIndicator()
+        NSApp.showProgressIndicator()
         
         //identify graphics at the tapped location
         self.mapView.identify(self.graphicsOverlay, screenPoint: screenPoint, tolerance: 5, returnPopupsOnly: false, maximumResults: 1) { [weak self] (result: AGSIdentifyGraphicsOverlayResult) -> Void in
             
             //hide progress indicator
-            self?.view.window?.hideProgressIndicator()
+            NSApp.hideProgressIndicator()
             
             if let error = result.error {
                 


### PR DESCRIPTION
This PR re-adds the indeterminate `NSProgressIndicator` to the main window's toolbar and changes it to the correct color.

This PR also moves `hideProgressIndicator` and `showProgressIndicator` to an extension of `NSApplication` rather than `NSWindow`. This provides a number of advantages:

- It implies the global nature of the indicator.
- Calls can be made cleanly via `NSApp` rather than finding the main window on every call.
- It works in cases where a view or its window property may be `nil`, such as during `viewDidLoad` or in a completion closure where the view has already been deallocated.