### PR TITLE
Disable editing the sample list

### DIFF
--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -799,7 +799,7 @@
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
-                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="hYO-vW-cOU">
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" title="Text Cell" id="hYO-vW-cOU">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
A recent refactor of the sample list made sample cells editable. This reverts that change.