### PR TITLE
Animate 3D Symbols: Uses system font for setting value labels

### DIFF
--- a/arcgis-runtime-samples-macos/Scenes/Animate 3D symbols/Animate3DSymbols.storyboard
+++ b/arcgis-runtime-samples-macos/Scenes/Animate 3D symbols/Animate3DSymbols.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="tLu-SQ-ZID">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="tLu-SQ-ZID">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
-        <capability name="system font weights other than Regular or Bold" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Animate3D SymbolsVC-->
@@ -150,7 +150,7 @@
                                                         </connections>
                                                     </slider>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tRL-2b-Sa7">
-                                                        <rect key="frame" x="18" y="215" width="112" height="17"/>
+                                                        <rect key="frame" x="18" y="215" width="113" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Distance (meters)" id="uJ6-DO-aeZ">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -188,25 +188,25 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fVs-ug-tgs">
-                                                        <rect key="frame" x="155" y="111" width="27" height="17"/>
+                                                        <rect key="frame" x="156" y="111" width="26" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="45º" id="b97-VQ-kwX">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="w15-1E-qhZ">
-                                                        <rect key="frame" x="163" y="163" width="19" height="17"/>
+                                                        <rect key="frame" x="164" y="163" width="18" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0º" id="q0D-Ll-EZO">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gQ4-OC-xrU">
-                                                        <rect key="frame" x="145" y="215" width="37" height="17"/>
+                                                        <rect key="frame" x="147" y="215" width="35" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="1000" id="xSA-YX-yqP">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -302,7 +302,7 @@
                                                         </constraints>
                                                     </customView>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qGj-Kx-zwR">
-                                                        <rect key="frame" x="18" y="85" width="106" height="17"/>
+                                                        <rect key="frame" x="18" y="85" width="107" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Altitude (meters)" id="lpz-0l-Qrr">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -334,33 +334,33 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RhA-be-FVM">
-                                                        <rect key="frame" x="145" y="85" width="37" height="17"/>
+                                                        <rect key="frame" x="147" y="85" width="35" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="1334" id="rrg-NS-zm8">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HZV-by-ecb">
-                                                        <rect key="frame" x="163" y="60" width="19" height="17"/>
+                                                        <rect key="frame" x="164" y="60" width="18" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0º" id="Wh3-3m-g1n">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="G0i-Fn-V38">
-                                                        <rect key="frame" x="163" y="35" width="19" height="17"/>
+                                                        <rect key="frame" x="164" y="35" width="18" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0º" id="YSZ-Bf-tBQ">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vpf-4Z-Xw6">
-                                                        <rect key="frame" x="163" y="10" width="19" height="17"/>
+                                                        <rect key="frame" x="164" y="10" width="18" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0º" id="gM4-bR-YOu">
-                                                            <font key="font" size="13" name="MonotypeSorts"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>


### PR DESCRIPTION
This fixes a problem where the values would appear as symbols due to using a missing font.

These changes were suggested by Xcode upon opening the storyboard.