### PR TITLE
Changes the generate offline map samples to use the temporary directory

### DIFF
--- a/arcgis-runtime-samples-macos/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -312,12 +312,12 @@ class GenerateOfflineMapOverridesViewController: NSViewController, AGSAuthentica
     private func getNewOfflineGeodatabaseURL()->URL{
        
         //get a suitable directory to place files
-        let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let directoryURL = FileManager.default.temporaryDirectory
         
         //create a unique name for the geodatabase based on current timestamp
         let formattedDate = ISO8601DateFormatter().string(from: Date())
         
-        return documentDirectoryURL.appendingPathComponent("\(formattedDate).geodatabase")
+        return directoryURL.appendingPathComponent("offline-map-overrides-\(formattedDate).geodatabase")
     }
     
 }

--- a/arcgis-runtime-samples-macos/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -247,12 +247,12 @@ class GenerateOfflineMapViewController: NSViewController, AGSAuthenticationManag
     private func getNewOfflineGeodatabaseURL()->URL{
        
         //get a suitable directory to place files
-        let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let directoryURL = FileManager.default.temporaryDirectory
         
         //create a unique name for the geodatabase based on current timestamp
         let formattedDate = ISO8601DateFormatter().string(from: Date())
         
-        return documentDirectoryURL.appendingPathComponent("\(formattedDate).geodatabase")
+        return directoryURL.appendingPathComponent("offline-map-\(formattedDate).geodatabase")
     }
     
 }


### PR DESCRIPTION
This keeps the samples from adding endless files to the user's documents directory.