### PR TITLE
Removes dark mode workaround.

### DIFF
--- a/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
+++ b/arcgis-runtime-samples-macos/Edit data/Edit features (connected)/EditFeaturesConnectedVC.swift
@@ -132,7 +132,6 @@ class EditFeaturesConnectedVC: NSViewController, AGSGeoViewTouchDelegate, AGSPop
         self.popupsVC.delegate = self
         
         //sizing
-        self.popupsVC.view.appearance = NSAppearance(named: .aqua)
         self.popupsVC.view.frame = self.containerView.bounds
         self.popupsVC.view.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
         self.containerView.addSubview(self.popupsVC.view)


### PR DESCRIPTION
`ArcGIS` does this automatically as of build `2196`.