### PR TITLE
Opens links in default web browser

### DIFF
--- a/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
+++ b/arcgis-runtime-samples-macos/Base.lproj/Main.storyboard
@@ -799,11 +799,11 @@
                                     </subviews>
                                     <nil key="backgroundColor"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="PHL-RX-KBc">
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="PHL-RX-KBc">
                                     <rect key="frame" x="1" y="283" width="198" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="cuZ-sx-OXh">
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="cuZ-sx-OXh">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -856,7 +856,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GxK-pS-yNo">
-                                        <rect key="frame" x="77" y="7" width="106" height="26"/>
+                                        <rect key="frame" x="77" y="7" width="106" height="25"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="zbD-en-mGK">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="menu"/>
@@ -920,6 +920,9 @@
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>
+                                <connections>
+                                    <outlet property="navigationDelegate" destination="YSS-cD-1jP" id="fZP-gI-ZSI"/>
+                                </connections>
                             </wkWebView>
                         </subviews>
                         <constraints>

--- a/arcgis-runtime-samples-macos/Content Display Logic/Controllers/ReadmeViewController.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Controllers/ReadmeViewController.swift
@@ -65,3 +65,17 @@ class ReadmeViewController: NSViewController {
         self.webView.loadHTMLString(string, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
     }
 }
+
+extension ReadmeViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        switch navigationAction.navigationType {
+        case .linkActivated:
+            if let url = navigationAction.request.url {
+                NSWorkspace.shared.open(url)
+            }
+            decisionHandler(.cancel)
+        default:
+            decisionHandler(.allow)
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, links would open in the web view itself. But because there were no navigation controls, there was no way to get back to the readme.