### PR TITLE
CollectionViewItemHeaderView: Sets text field background style rather…

### DIFF
--- a/arcgis-runtime-samples-macos/Content Display Logic/Sample Collection View/CollectionViewItem.swift
+++ b/arcgis-runtime-samples-macos/Content Display Logic/Sample Collection View/CollectionViewItem.swift
@@ -34,9 +34,7 @@ class CollectionViewItem: NSCollectionViewItem {
 class CollectionViewItemHeaderView: NSView {
     @IBOutlet var textField: NSTextField! {
         didSet {
-            if #available(OSX 10.14, *) {
-                textField.appearance = NSAppearance(named: .darkAqua)
-            }
+            textField.cell?.backgroundStyle = .emphasized
         }
     }
     


### PR DESCRIPTION
… than appearance

Apparently this is the correct way of ensuring that the text field's text always has a light appearance. Although as far as I can tell, there isn't a functional different between the two.