### PR TITLE
Removes usage of NSSearchPathForDirectoriesInDomains

### DIFF
--- a/arcgis-runtime-samples-macos/Features/Generate geodatabase/GenerateGeodatabaseVC.swift
+++ b/arcgis-runtime-samples-macos/Features/Generate geodatabase/GenerateGeodatabaseVC.swift
@@ -103,11 +103,13 @@ class GenerateGeodatabaseVC: NSViewController {
                 //create a unique name for the geodatabase based on current timestamp
                 let dateFormatter = ISO8601DateFormatter()
                 
-                let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
-                let fullPath = "\(path)/\(dateFormatter.string(from: Date())).geodatabase"
+                let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+                let downloadFileURL = documentDirectoryURL
+                    .appendingPathComponent(dateFormatter.string(from: Date()))
+                    .appendingPathExtension("geodatabase")
                 
                 //request a job to generate the geodatabase
-                let generateJob = self.syncTask.generateJob(with: params, downloadFileURL: URL(string: fullPath)!)
+                let generateJob = self.syncTask.generateJob(with: params, downloadFileURL: downloadFileURL)
                 self.activeJob = generateJob
                 
                 //show progress bar


### PR DESCRIPTION
The documentation discourages using `NSSearchPathForDirectoriesInDomains`.