### PR TITLE
Enables return_arrow_whitespace linting rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,7 +14,6 @@ disabled_rules: # rule identifiers to exclude from running
   - mark
   - multiple_closures_with_trailing_closure
   - redundant_discardable_let
-  - return_arrow_whitespace
   - statement_position
   - syntactic_sugar
   - trailing_semicolon


### PR DESCRIPTION
We're already following the [rule](https://github.com/realm/SwiftLint/blob/master/Rules.md#returning-whitespace), so it makes sense to enable it.