### PR TITLE
Disables the notification_center_detachment SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules: # rule identifiers to exclude from running
   - function_body_length
   - identifier_name
   - line_length
+  - notification_center_detachment
   - trailing_whitespace
   - type_name
   - unused_closure_parameter


### PR DESCRIPTION
This rule is unnecessary and we don't use it on iOS.