### PR TITLE
Enables the function_body_length SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,6 @@ disabled_rules: # rule identifiers to exclude from running
   - file_length
   - for_where
   - force_cast
-  - function_body_length
   - identifier_name
   - line_length
   - trailing_whitespace

--- a/arcgis-runtime-samples-macos/Analysis/Viewshed (GeoElement)/ViewshedGeoElementViewController.swift
+++ b/arcgis-runtime-samples-macos/Analysis/Viewshed (GeoElement)/ViewshedGeoElementViewController.swift
@@ -27,6 +27,20 @@ class ViewshedGeoElementViewController: NSViewController, AGSGeoViewTouchDelegat
         
         // set the sceneView's touch delegate so we can get user taps
         sceneView.touchDelegate = self
+
+        let graphicsOverlay = makeGraphicsOverlay()
+        sceneView.graphicsOverlays.add(graphicsOverlay)
+        
+        let analysisOverlay = makeAnalysisOverlay()
+        sceneView.analysisOverlays.add(analysisOverlay)
+        
+        let cameraController = makeCameraController()
+        sceneView.cameraController = cameraController
+        
+        sceneView.scene = makeScene()
+    }
+    
+    private func makeScene() -> AGSScene {
         
         // create the scene
         let scene = AGSScene(basemap: .imagery())
@@ -45,10 +59,14 @@ class ViewshedGeoElementViewController: NSViewController, AGSGeoViewTouchDelegat
         let buildings = AGSArcGISSceneLayer(url: brestBuildingsServiceURL)
         scene.operationalLayers.add(buildings)
         
+        return scene
+    }
+    
+    private func makeGraphicsOverlay() -> AGSGraphicsOverlay {
+        
         // create a graphics overlay for the tank
         let graphicsOverlay = AGSGraphicsOverlay()
         graphicsOverlay.sceneProperties = AGSLayerSceneProperties(surfacePlacement: .relative)
-        sceneView.graphicsOverlays.add(graphicsOverlay)
         
         // set up heading expression for tank
         let renderer3D = AGSSimpleRenderer()
@@ -61,19 +79,29 @@ class ViewshedGeoElementViewController: NSViewController, AGSGeoViewTouchDelegat
         let tankSymbol = AGSModelSceneSymbol(name: "bradle", extension: "3ds", scale: 10.0)
         tankSymbol.heading = 90.0
         tankSymbol.anchorPosition = .bottom
-        tank = AGSGraphic(geometry: AGSPoint(x: -4.506390, y: 48.385624, spatialReference: .wgs84()),
-                          symbol: tankSymbol,
-                          attributes: ["HEADING": 0.0])
+        tank = AGSGraphic(
+            geometry: AGSPoint(x: -4.506390,
+                               y: 48.385624,
+                               spatialReference: .wgs84()),
+            symbol: tankSymbol,
+            attributes: ["HEADING": 0.0]
+        )
         graphicsOverlay.graphics.add(tank)
+        return graphicsOverlay
+    }
+    
+    private func makeAnalysisOverlay() -> AGSAnalysisOverlay {
         
         // create a viewshed to attach to the tank
-        let geoElementViewshed = AGSGeoElementViewshed(geoElement: tank,
-                                                       horizontalAngle: 90.0,
-                                                       verticalAngle: 40.0,
-                                                       minDistance: 0.1,
-                                                       maxDistance: 250.0,
-                                                       headingOffset: 0.0,
-                                                       pitchOffset: 0.0)
+        let geoElementViewshed = AGSGeoElementViewshed(
+            geoElement: tank,
+            horizontalAngle: 90.0,
+            verticalAngle: 40.0,
+            minDistance: 0.1,
+            maxDistance: 250.0,
+            headingOffset: 0.0,
+            pitchOffset: 0.0
+        )
         
         // offset viewshed observer location to top of tank
         geoElementViewshed.offsetZ = 3.0
@@ -81,16 +109,16 @@ class ViewshedGeoElementViewController: NSViewController, AGSGeoViewTouchDelegat
         // create an analysis overlay to add the viewshed to the scene view
         let analysisOverlay = AGSAnalysisOverlay()
         analysisOverlay.analyses.add(geoElementViewshed)
-        sceneView.analysisOverlays.add(analysisOverlay)
-        
+        return analysisOverlay
+    }
+    
+    private func makeCameraController() -> AGSCameraController {
         // set camera controller to follow tank
         let cameraController = AGSOrbitGeoElementCameraController(targetGeoElement: tank, distance: 200.0)
         cameraController.cameraPitchOffset = 45.0
-        sceneView.cameraController = cameraController
-        
-        sceneView.scene = scene
+        return cameraController
     }
-    
+
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
         // set the new waypoint
         waypoint = mapPoint

--- a/arcgis-runtime-samples-macos/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-runtime-samples-macos/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -95,7 +95,7 @@ class GraphicsWithSymbolsViewController: NSViewController {
     
     private func addBoatTrip(to graphicsOverlay: AGSGraphicsOverlay) {
         //boat trip geometry
-        let boatRoute = self.boatTripGeometry()
+        let boatRoute = boatTripGeometry
         
         //define a line symbol
         let lineSymbol = AGSSimpleLineSymbol(
@@ -112,7 +112,7 @@ class GraphicsWithSymbolsViewController: NSViewController {
     
     private func addNestingGround(to graphicsOverlay: AGSGraphicsOverlay) {
         //nesting ground geometry
-        let nestingGround = self.nestingGroundGeometry()
+        let nestingGround = nestingGroundGeometry
         
         //define the fill symbol and outline
         let outlineSymbol = AGSSimpleLineSymbol(
@@ -131,7 +131,7 @@ class GraphicsWithSymbolsViewController: NSViewController {
         graphicsOverlay.graphics.add(nestingGraphic)
     }
     
-    private func boatTripGeometry() -> AGSPolyline {
+    private let boatTripGeometry: AGSPolyline = {
         //create a polyline
         let boatRoute = AGSPolylineBuilder(spatialReference: .wgs84())
         
@@ -196,9 +196,9 @@ class GraphicsWithSymbolsViewController: NSViewController {
         boatRoute.addPointWith(x: -2.718307461756433, y: 56.06147084563517)
         
         return boatRoute.toGeometry()
-    }
+    }()
     
-    private func nestingGroundGeometry() -> AGSPolygon {
+    private let nestingGroundGeometry: AGSPolygon = {
         //create a polygon
         let nestingGround = AGSPolygonBuilder(spatialReference: .wgs84())
         
@@ -230,6 +230,6 @@ class GraphicsWithSymbolsViewController: NSViewController {
         nestingGround.addPointWith(x: -2.643077012566659, y: 56.077125346044475)
         
         return nestingGround.toGeometry()
-    }
+    }()
     
 }

--- a/arcgis-runtime-samples-macos/Layers/List KML contents/ListKMLContentsViewController.swift
+++ b/arcgis-runtime-samples-macos/Layers/List KML contents/ListKMLContentsViewController.swift
@@ -158,71 +158,90 @@ class ListKMLContentsViewController: NSViewController {
     private func viewpoint(for node: AGSKMLNode) -> AGSViewpoint? {
         
         if let kmlViewpoint = node.viewpoint {
-            // Convert the KML viewpoint to a viewpoint for the scene.
-            // The KML viewpoint may not correspond to the node's geometry.
             
-            switch kmlViewpoint.type {
-            case .lookAt:
-                var lookAtPoint = kmlViewpoint.location
-                if kmlViewpoint.altitudeMode != .absolute {
-                    // if the elevation is relative, account for the surface's elevation
-                    let elevation = sceneSurfaceElevation(for: lookAtPoint) ?? 0
-                    lookAtPoint = AGSPoint(x: lookAtPoint.x, y: lookAtPoint.y, z: lookAtPoint.z + elevation, spatialReference: lookAtPoint.spatialReference)
-                }
-                let camera = AGSCamera(lookAt: lookAtPoint,
-                                       distance: kmlViewpoint.range,
-                                       heading: kmlViewpoint.heading,
-                                       pitch: kmlViewpoint.pitch,
-                                       roll: kmlViewpoint.roll)
-                // only the camera parameter is used by the scene
-                return AGSViewpoint(center: kmlViewpoint.location, scale: 1, camera: camera)
-            case .camera:
-                // convert the KML viewpoint to a camera
-                let camera = AGSCamera(location: kmlViewpoint.location,
-                                       heading: kmlViewpoint.heading,
-                                       pitch: kmlViewpoint.pitch,
-                                       roll: kmlViewpoint.roll)
-                // only the camera parameter is used by the scene
-                return AGSViewpoint(center: kmlViewpoint.location, scale: 1, camera: camera)
-            case .unknown:
-                print("Unexpected AGSKMLViewpointType \(kmlViewpoint.type)")
-                return nil
-            }
-        }
-        // the node does not have a predefined viewpoint, so create a viewpoint based on its extent
-        else if let extent = node.extent,
-            // some nodes do not include a geometry, so check that the extent isn't empty
-            !extent.isEmpty {
+            return viewpointFromKMLViewpoint(kmlViewpoint)
             
-            var center = extent.center
-            // take the scene's elevation into account
-            let elevation = sceneSurfaceElevation(for: center) ?? 0
-            
-            // It's possible for `isEmpty` to be false but for width/height to still be zero.
-            if extent.width == 0,
-                extent.height == 0 {
-
-                center = AGSPoint(x: center.x, y: center.y, z: center.z + elevation, spatialReference: extent.spatialReference)
-                // Defaults based on Google Earth.
-                let camera = AGSCamera(lookAt: center, distance: 1000, heading: 0, pitch: 45, roll: 0)
-                // only the camera parameter is used by the scene
-                return AGSViewpoint(targetExtent: extent, camera: camera)
-
-            } else {
-                // expand the extent to give some margins when framing the node
-                let bufferRadius = [extent.width, extent.height].max()! / 20
-                let bufferedExtent = AGSEnvelope(xMin: extent.xMin - bufferRadius,
-                                                 yMin: extent.yMin - bufferRadius,
-                                                 zMin: extent.zMin - bufferRadius + elevation,
-                                                 xMax: extent.xMax + bufferRadius,
-                                                 yMax: extent.yMax + bufferRadius,
-                                                 zMax: extent.zMax + bufferRadius + elevation,
-                                                 spatialReference: .wgs84())
-                return AGSViewpoint(targetExtent: bufferedExtent)
-            }
+        } else if let extent = node.extent {
+            // the node does not have a predefined viewpoint, so create a viewpoint based on its extent
+            return viewpointFromKMLNodeExtent(extent)
         }
         // the node doesn't have a predefined viewpoint or geometry
         return nil
+    }
+    
+    // Converts the KML viewpoint to a viewpoint for the scene.
+    // The KML viewpoint may not correspond to the node's geometry.
+    private func viewpointFromKMLViewpoint(_ kmlViewpoint: AGSKMLViewpoint) -> AGSViewpoint? {
+        
+        switch kmlViewpoint.type {
+        case .lookAt:
+            var lookAtPoint = kmlViewpoint.location
+            if kmlViewpoint.altitudeMode != .absolute {
+                // if the elevation is relative, account for the surface's elevation
+                let elevation = sceneSurfaceElevation(for: lookAtPoint) ?? 0
+                lookAtPoint = AGSPoint(x: lookAtPoint.x, y: lookAtPoint.y, z: lookAtPoint.z + elevation, spatialReference: lookAtPoint.spatialReference)
+            }
+            let camera = AGSCamera(lookAt: lookAtPoint,
+                                   distance: kmlViewpoint.range,
+                                   heading: kmlViewpoint.heading,
+                                   pitch: kmlViewpoint.pitch,
+                                   roll: kmlViewpoint.roll)
+            // only the camera parameter is used by the scene
+            return AGSViewpoint(center: kmlViewpoint.location, scale: 1, camera: camera)
+        case .camera:
+            // convert the KML viewpoint to a camera
+            let camera = AGSCamera(location: kmlViewpoint.location,
+                                   heading: kmlViewpoint.heading,
+                                   pitch: kmlViewpoint.pitch,
+                                   roll: kmlViewpoint.roll)
+            // only the camera parameter is used by the scene
+            return AGSViewpoint(center: kmlViewpoint.location, scale: 1, camera: camera)
+        case .unknown:
+            print("Unexpected AGSKMLViewpointType \(kmlViewpoint.type)")
+            return nil
+        }
+    }
+    
+    /// Creates a default viewpoint framing the node based on its extent.
+    private func viewpointFromKMLNodeExtent(_ extent: AGSEnvelope) -> AGSViewpoint? {
+        
+        // some nodes do not include a geometry, so check that the extent isn't empty
+        guard !extent.isEmpty else {
+            return nil
+        }
+        
+        let extentCenter = extent.center
+        // take the scene's elevation into account
+        let elevation = sceneSurfaceElevation(for: extentCenter) ?? 0
+        
+        // It's possible for `isEmpty` to be false but for width/height to still be zero.
+        if extent.width == 0,
+            extent.height == 0 {
+            
+            let lookAtPoint = AGSPoint(
+                x: extentCenter.x,
+                y: extentCenter.y,
+                z: extentCenter.z + elevation,
+                spatialReference: extent.spatialReference
+            )
+            // Defaults based on Google Earth.
+            let camera = AGSCamera(lookAt: lookAtPoint, distance: 1000, heading: 0, pitch: 45, roll: 0)
+            // only the camera parameter is used by the scene
+            return AGSViewpoint(targetExtent: extent, camera: camera)
+        } else {
+            // expand the extent to give some margins when framing the node
+            let bufferRadius = max(extent.width, extent.height) / 20
+            let bufferedExtent = AGSEnvelope(
+                xMin: extent.xMin - bufferRadius,
+                yMin: extent.yMin - bufferRadius,
+                zMin: extent.zMin - bufferRadius + elevation,
+                xMax: extent.xMax + bufferRadius,
+                yMax: extent.yMax + bufferRadius,
+                zMax: extent.zMax + bufferRadius + elevation,
+                spatialReference: .wgs84()
+            )
+            return AGSViewpoint(targetExtent: bufferedExtent)
+        }
     }
     
 }

--- a/arcgis-runtime-samples-macos/Maps/Read a geopackage/ReadGeopackageViewController.swift
+++ b/arcgis-runtime-samples-macos/Maps/Read a geopackage/ReadGeopackageViewController.swift
@@ -69,8 +69,7 @@ class ReadGeopackageViewController: NSViewController {
             
             if let error = error {
                 print("Error loading the geopackage: \(error.localizedDescription)")
-            }
-            else {
+            } else {
                 
                 // Create feature layers for each feature table in the geopackage.
                 let featureLayers = geoPackage.geoPackageFeatureTables.map { AGSFeatureLayer(featureTable: $0) }

--- a/arcgis-runtime-samples-macosTests/CategoryTests.swift
+++ b/arcgis-runtime-samples-macosTests/CategoryTests.swift
@@ -18,36 +18,38 @@ import XCTest
 @testable import ArcGIS_Runtime_SDK_Samples
 
 class CategoryTests: XCTestCase {
+    
+    let sampleData = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>Maps</string>
+            <key>children</key>
+            <array>
+                <dict>
+                    <key>displayName</key>
+                    <string>Display a map</string>
+                    <key>storyboardName</key>
+                    <string>DisplayMap</string>
+                    <key>descriptionText</key>
+                    <string>This sample shows you how to display a map with imagery basemap</string>
+                </dict>
+                <dict>
+                    <key>displayName</key>
+                    <string>Change map view background</string>
+                    <key>storyboardName</key>
+                    <string>ChangeMapViewBackground</string>
+                    <key>descriptionText</key>
+                    <string>This sample shows you how to customize map view's background grid</string>
+                </dict>
+            </array>
+        </dict>
+        </plist>
+    """.data(using: .utf8)!
+    
     func testInitFromDecoder() {
-        let sampleData = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-                <key>displayName</key>
-                <string>Maps</string>
-                <key>children</key>
-                <array>
-                    <dict>
-                        <key>displayName</key>
-                        <string>Display a map</string>
-                        <key>storyboardName</key>
-                        <string>DisplayMap</string>
-                        <key>descriptionText</key>
-                        <string>This sample shows you how to display a map with imagery basemap</string>
-                    </dict>
-                    <dict>
-                        <key>displayName</key>
-                        <string>Change map view background</string>
-                        <key>storyboardName</key>
-                        <string>ChangeMapViewBackground</string>
-                        <key>descriptionText</key>
-                        <string>This sample shows you how to customize map view's background grid</string>
-                    </dict>
-                </array>
-            </dict>
-            </plist>
-        """.data(using: .utf8)!
         let expectedCategory = ArcGIS_Runtime_SDK_Samples.Category(
             name: "Maps",
             samples: [


### PR DESCRIPTION
These changes are exactly the same as those in the [iOS implementation](https://github.com/Esri/arcgis-runtime-samples-ios/pull/582) for the affected samples.