### PR TITLE
Enables the untyped_error_in_catch SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -62,6 +62,7 @@ opt_in_rules: # some rules are only opt-in
   - toggle_bool
   - unused_import
   - unused_private_declaration
+  - untyped_error_in_catch
   - vertical_parameter_alignment_on_call
   - yoda_condition
 


### PR DESCRIPTION
This rule does not affect the code but is a nice-to-have in case of future changes and matches the iOS rule.